### PR TITLE
[REFACTOR] BusinessException 공통 응답 구조 수정

### DIFF
--- a/bank/src/main/java/com/fisa/bank/common/presentation/exception/GlobalExceptionHandler.java
+++ b/bank/src/main/java/com/fisa/bank/common/presentation/exception/GlobalExceptionHandler.java
@@ -6,7 +6,6 @@ import com.fisa.bank.common.presentation.response.ApiResponseGenerator;
 import com.fisa.bank.common.presentation.response.body.FailureBody;
 import com.fisa.bank.common.presentation.response.code.ApiResponseCode.ErrorResponseCode;
 import com.fisa.bank.common.presentation.response.code.BusinessErrorCode;
-import java.util.Arrays;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/bank/src/main/java/com/fisa/bank/common/presentation/exception/GlobalExceptionHandler.java
+++ b/bank/src/main/java/com/fisa/bank/common/presentation/exception/GlobalExceptionHandler.java
@@ -6,6 +6,8 @@ import com.fisa.bank.common.presentation.response.ApiResponseGenerator;
 import com.fisa.bank.common.presentation.response.body.FailureBody;
 import com.fisa.bank.common.presentation.response.code.ApiResponseCode.ErrorResponseCode;
 import com.fisa.bank.common.presentation.response.code.BusinessErrorCode;
+import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 // 애플리케이션 전역 Exception 핸들러
 // BusinessException을 제외하고, 다른 종류의 예외들도 추가할 수 있다.
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     /**
@@ -23,7 +26,7 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(BusinessException.class)
     public ApiResponse<FailureBody> handle(BusinessException e){
-        // BusinessException 과 관련된 HttpStatus, ErrorCode, Message 를 가져오기
+        log.warn(e.getMessage());
         ErrorResponseCode<BusinessException> errorCode = BusinessErrorCode.find(e);
 
         return ApiResponseGenerator.fail(errorCode, e);
@@ -36,6 +39,7 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(RuntimeException.class)
     public ApiResponse<FailureBody> handle(RuntimeException e){
+        log.warn(e.getMessage());
         return ApiResponseGenerator.fail(HttpStatus.INTERNAL_SERVER_ERROR, "500", e.getMessage());
     }
 

--- a/bank/src/main/java/com/fisa/bank/common/presentation/exception/GlobalExceptionHandler.java
+++ b/bank/src/main/java/com/fisa/bank/common/presentation/exception/GlobalExceptionHandler.java
@@ -26,7 +26,7 @@ public class GlobalExceptionHandler {
         // BusinessException 과 관련된 HttpStatus, ErrorCode, Message 를 가져오기
         ErrorResponseCode<BusinessException> errorCode = BusinessErrorCode.find(e);
 
-        return ApiResponseGenerator.fail(errorCode);
+        return ApiResponseGenerator.fail(errorCode, e);
     }
 
     /**

--- a/bank/src/main/java/com/fisa/bank/common/presentation/exception/GlobalExceptionHandler.java
+++ b/bank/src/main/java/com/fisa/bank/common/presentation/exception/GlobalExceptionHandler.java
@@ -26,7 +26,7 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(BusinessException.class)
     public ApiResponse<FailureBody> handle(BusinessException e){
-        log.warn(e.getMessage());
+        log.warn(e.getMessage(), e);
         ErrorResponseCode<BusinessException> errorCode = BusinessErrorCode.find(e);
 
         return ApiResponseGenerator.fail(errorCode, e);
@@ -39,7 +39,7 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(RuntimeException.class)
     public ApiResponse<FailureBody> handle(RuntimeException e){
-        log.warn(e.getMessage());
+        log.error(e.getMessage(), e);
         return ApiResponseGenerator.fail(HttpStatus.INTERNAL_SERVER_ERROR, "500", e.getMessage());
     }
 

--- a/bank/src/main/java/com/fisa/bank/common/presentation/response/ApiResponseGenerator.java
+++ b/bank/src/main/java/com/fisa/bank/common/presentation/response/ApiResponseGenerator.java
@@ -1,12 +1,11 @@
 package com.fisa.bank.common.presentation.response;
 
+import com.fisa.bank.common.application.exception.BusinessException;
 import com.fisa.bank.common.presentation.response.body.FailureBody;
 import com.fisa.bank.common.presentation.response.body.SuccessBody;
-import com.fisa.bank.common.presentation.response.code.ApiResponseCode;
 import com.fisa.bank.common.presentation.response.code.ApiResponseCode.ErrorResponseCode;
 import com.fisa.bank.common.presentation.response.code.ApiResponseCode.SuccessResponseCode;
 import com.fisa.bank.common.presentation.response.code.MessageCode;
-import com.fisa.bank.common.presentation.response.code.ResponseCode;
 import org.springframework.http.HttpStatus;
 
 public class ApiResponseGenerator {
@@ -45,13 +44,26 @@ public class ApiResponseGenerator {
         return new ApiResponse<>(status, new SuccessBody<>(code, message, body));
     }
 
-    public static ApiResponse<FailureBody> fail(ErrorResponseCode<? extends Throwable> responseCode){
+    /**
+     * BusinessException 과 ErrorResponseCode를 사용해서 응답 객체를 생성합니다.
+     * @param responseCode
+     * @param e
+     * @return
+     */
+    public static ApiResponse<FailureBody> fail(ErrorResponseCode<? extends Throwable> responseCode, BusinessException e){
         HttpStatus status = responseCode.getStatus();
-        String errorCode = responseCode.getCode();
-        String message = responseCode.getMessage();
+        String errorCode = e.getErrorCode();
+        String message = e.getMessage();
         return new ApiResponse<>(status, new FailureBody(errorCode, message));
     }
 
+    /**
+     * BusinessException이 아닌, status, errorCode, message를 전부 받아서 응답 객체를 생성합니다.
+     * @param status
+     * @param errorCode
+     * @param message
+     * @return
+     */
     public static ApiResponse<FailureBody> fail(HttpStatus status, String errorCode, String message){
         return new ApiResponse<>(status, new FailureBody(errorCode, message));
     }

--- a/bank/src/main/java/com/fisa/bank/common/presentation/response/code/BusinessErrorCode.java
+++ b/bank/src/main/java/com/fisa/bank/common/presentation/response/code/BusinessErrorCode.java
@@ -17,26 +17,24 @@ public enum BusinessErrorCode implements ErrorResponseCode<BusinessException> {
      * 여기에 커스텀 BusinessException을 정의하면 됩니다.
      */
 
-    INVALID_PASSWORD_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, InvalidPasswordFormatException.EXCEPTION),
-    INVALID_AUTH_INFO_EXCEPTION(HttpStatus.BAD_REQUEST, InvalidAuthInfoException.EXCEPTION);
+    INVALID_PASSWORD_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, InvalidPasswordFormatException.class),
+    INVALID_AUTH_INFO_EXCEPTION(HttpStatus.BAD_REQUEST, InvalidAuthInfoException.class);
 
     private final HttpStatus status;
-    @Getter  private final BusinessException exception;
+    @Getter private final Class<? extends BusinessException> exception;
 
-    <T extends BusinessException> BusinessErrorCode(HttpStatus status, T exception){
+    BusinessErrorCode(HttpStatus status, Class<? extends BusinessException> eClass){
         this.status = status;
-        this.exception = exception;
+        this.exception = eClass;
     }
-
 
     @Override
     public HttpStatus getStatus() { return this.status; }
 
     @Override
-    public String getCode() { return exception.getErrorCode(); }
-
+    public String getCode() { throw new UnsupportedOperationException("You should use errorCode, message in the BusinessException"); }
     @Override
-    public String getMessage() { return exception.getMessage(); }
+    public String getMessage() { throw new UnsupportedOperationException("You should use errorCode, message in the BusinessException"); }
 
     public static ErrorResponseCode<BusinessException> find(BusinessException exception){
         BusinessErrorCode errorResponseCode =  map.get(exception.getClass());
@@ -46,12 +44,15 @@ public enum BusinessErrorCode implements ErrorResponseCode<BusinessException> {
         throw new IllegalArgumentException("Not mapped Exception");
     }
 
+    /**
+     * 커스텀 Exception에 맞는 ErrorCode를 매핑하는 저장소
+     */
     private static final Map<Class<? extends BusinessException>, BusinessErrorCode> map = new ConcurrentHashMap<>();
 
     static {
         Arrays.stream(BusinessErrorCode.values())
                 .forEach(errorCode -> {
-                    Class<? extends BusinessException> eClass = errorCode.exception.getClass();
+                    Class<? extends BusinessException> eClass = errorCode.exception;
                     map.put(eClass, errorCode);
                 });
     }

--- a/bank/src/main/java/com/fisa/bank/user/application/exception/InvalidAuthInfoException.java
+++ b/bank/src/main/java/com/fisa/bank/user/application/exception/InvalidAuthInfoException.java
@@ -4,13 +4,11 @@ import com.fisa.bank.common.application.exception.BusinessException;
 
 public class InvalidAuthInfoException extends BusinessException {
 
-    public static final InvalidAuthInfoException EXCEPTION = new InvalidAuthInfoException();
+    private static final String errorCode = "U1000";
+    private static final String message = "이미 존재하는 ID 입니다. : %s";
 
-    private static final String errorCode = "1000";
-    private static final String message = "이미 존재하는 ID 입니다.";
-
-    private InvalidAuthInfoException() {
-        super(errorCode, message);
+    public InvalidAuthInfoException(String loginId) {
+        super(errorCode, String.format(message, loginId));
     }
 
 }

--- a/bank/src/main/java/com/fisa/bank/user/application/exception/InvalidPasswordFormatException.java
+++ b/bank/src/main/java/com/fisa/bank/user/application/exception/InvalidPasswordFormatException.java
@@ -4,12 +4,10 @@ import com.fisa.bank.common.application.exception.BusinessException;
 
 public class InvalidPasswordFormatException extends BusinessException {
 
-    public static final InvalidPasswordFormatException EXCEPTION = new InvalidPasswordFormatException();
-
     private static final String errorCode = "1001";
     private static final String message = "비밀번호 규칙에 맞지 않습니다.";
 
-    private InvalidPasswordFormatException() {
+    public InvalidPasswordFormatException() {
         super(errorCode, message);
     }
 }

--- a/bank/src/main/java/com/fisa/bank/user/application/service/UserService.java
+++ b/bank/src/main/java/com/fisa/bank/user/application/service/UserService.java
@@ -23,7 +23,7 @@ public class UserService {
     @Transactional
     public boolean create(UserCreateRequest request){
         if(authRepository.existsById(request.loginId()))
-            throw InvalidAuthInfoException.EXCEPTION;
+            throw new InvalidAuthInfoException(request.loginId());
 
         String encryptedPassword = passwordUtil.encrypt(request.password());
 

--- a/bank/src/main/java/com/fisa/bank/user/application/util/PasswordUtil.java
+++ b/bank/src/main/java/com/fisa/bank/user/application/util/PasswordUtil.java
@@ -15,7 +15,7 @@ public class PasswordUtil {
     public String encrypt(String password){
 
         if(!validator.validate(password))
-            throw InvalidPasswordFormatException.EXCEPTION;
+            throw new InvalidPasswordFormatException();
 
         return passwordEncoder.encode(password);
     }


### PR DESCRIPTION
closes #17 

## (변경) BusinessException 구조 변경
#11 에서 애플리케이션 공통 Exception 구조를 정의하고, GlobalExceptionHandler 를 설계하였습니다.
싱글톤 방식의 Exception 구조를 사용하려다 보니, Stack Trace가 추적되지 않는 어려움이 존재하였고
이를 해결하기 위해서 BusinessException 구조를 변경하고자 합니다.

### 기존
1. 커스텀 BusinessException은 `public static final` 로 내부에 자기 자신을 필드로 갖습니다. 커스텀 예외를 던져야 하는 곳에서 `public static final` 필드를 사용하여 에러를 던집니다.
2. presentation 계층에서 `ErrorResponseCode`에 BusinessException 은 어떤 HttpStatus를 가져야 하는지 정의하고 있습니다.

### 변경
1. 더 이상 싱글톤 방식을 보장하지 않습니다. `public static final` 을 사용하지 않습니다.
2. 커스텀 예외를 던져야 할 경우에, `throw new CustomBusinessException()`을 사용하여 예외를 던집니다.
3. `ErrorResponseCode` 또한, `Class<? extends BusinessException>` 을 기반으로 HttpStatus 와 Exception을 매핑합니다.

## BusinessException - 커스텀 예외 정의하기
1. 예외는 필요한 곳에서 `throw new CustomBusinessException()` 방식으로 던져서 사용합니다.
    더 이상 `public static final`을 사용하지 않습니다.
2. 예외 메세지에, 동적으로 들어가는 데이터가 있을 경우, `public CustomBusinessException(UserId userId)` 처럼 생성자를 추가로 정의하여 필요한 데이터를 전달합니다.

## To Reviewers
수정하거나 개선하고 싶은 내용이 있다면, 언제든지 코멘트 달아주시면 감사하겠습니다.

