### PR TITLE
[REFACTOR] 필터체인 설정 간소화

### DIFF
--- a/bank/build.gradle
+++ b/bank/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 	// validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	// swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 	// Flyway
 	implementation 'org.flywaydb:flyway-core'
 	implementation "org.flywaydb:flyway-mysql"

--- a/bank/src/main/java/com/fisa/bank/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/SecurityFilterChainConfig.java
@@ -100,13 +100,13 @@ public class SecurityFilterChainConfig {
                 matcher
                     .requestMatchers(
                         HttpMethod.GET,
-                        "/api/loans",
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/swagger-resources/**",
                         "/api/loans/products/**",
                         "/api/interests/**")
-                    .requestMatchers(HttpMethod.POST, "/api/loans", "/api/login", "/api/users"))
+                    .requestMatchers(HttpMethod.POST, "/api/loans", "/api/login", "/api/users")
+                    .requestMatchers(HttpMethod.DELETE, "/api/loans/products/{loanProductId}"))
         .authorizeHttpRequests(request -> request.anyRequest().permitAll());
 
     http.addFilterBefore(loginFilter, UsernamePasswordAuthenticationFilter.class); // login 전용 필터

--- a/bank/src/main/java/com/fisa/bank/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/SecurityFilterChainConfig.java
@@ -24,14 +24,14 @@ import org.springframework.security.web.authentication.LoginUrlAuthenticationEnt
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.session.DisableEncodeUrlFilter;
 
-import com.fisa.bank.common.config.security.resource.AccessTokenEntryPoint;
+import com.fisa.bank.common.config.security.resource.NotFoundAccessTokenEntryPoint;
 import com.fisa.bank.common.config.security.resource.UnknownEndPointFilter;
 
 @Configuration
 @RequiredArgsConstructor
 public class SecurityFilterChainConfig {
 
-  private final AccessTokenEntryPoint accessTokenEntryPoint;
+  private final NotFoundAccessTokenEntryPoint accessTokenEntryPoint;
 
   @Bean
   @Order(1)

--- a/bank/src/main/java/com/fisa/bank/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/SecurityFilterChainConfig.java
@@ -100,6 +100,8 @@ public class SecurityFilterChainConfig {
                 matcher
                     .requestMatchers(
                         HttpMethod.GET,
+                        "/api/loans/products",
+                        "/api/loans/{loanProductId}",
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/swagger-resources/**",

--- a/bank/src/main/java/com/fisa/bank/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/SecurityFilterChainConfig.java
@@ -24,14 +24,14 @@ import org.springframework.security.web.authentication.LoginUrlAuthenticationEnt
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.session.DisableEncodeUrlFilter;
 
-import com.fisa.bank.common.config.security.resource.NotFoundAccessTokenEntryPoint;
+import com.fisa.bank.common.config.security.resource.RequiredAuthenticationEntryPoint;
 import com.fisa.bank.common.config.security.resource.UnknownEndPointFilter;
 
 @Configuration
 @RequiredArgsConstructor
 public class SecurityFilterChainConfig {
 
-  private final NotFoundAccessTokenEntryPoint accessTokenEntryPoint;
+  private final RequiredAuthenticationEntryPoint requiredAuthenticationEntryPoint;
 
   @Bean
   @Order(1)
@@ -133,7 +133,7 @@ public class SecurityFilterChainConfig {
         .authorizeHttpRequests(request -> request.anyRequest().authenticated());
 
     http.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
-    http.exceptionHandling(ex -> ex.authenticationEntryPoint(accessTokenEntryPoint));
+    http.exceptionHandling(ex -> ex.authenticationEntryPoint(requiredAuthenticationEntryPoint));
     http.oauth2ResourceServer(AbstractHttpConfigurer::disable);
     return http.build();
   }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/SecurityFilterChainConfig.java
@@ -102,11 +102,11 @@ public class SecurityFilterChainConfig {
                         HttpMethod.GET,
                         "/api/loans/products",
                         "/api/loans/{loanProductId}",
-                        "/swagger-ui/**",
-                        "/v3/api-docs/**",
-                        "/swagger-resources/**",
-                        "/api/loans/products/**",
-                        "/api/interests/**")
+                        "/api/interests/{loanProductId}",
+                        "/swagger-ui/index.html", // TODO: Swagger 전용 필터체인으로 분리
+                        "/v3/api-docs", // TODO: Swagger 전용 필터체인으로 분리
+                        "/swagger-resources/**" // TODO: Swagger 전용 필터체인으로 분리
+                        )
                     .requestMatchers(HttpMethod.POST, "/api/loans", "/api/login", "/api/users")
                     .requestMatchers(HttpMethod.DELETE, "/api/loans/products/{loanProductId}"))
         .authorizeHttpRequests(request -> request.anyRequest().permitAll());
@@ -130,8 +130,22 @@ public class SecurityFilterChainConfig {
     http.securityMatchers(
             matcher ->
                 matcher
-                    .requestMatchers(HttpMethod.POST, "/api/loans/**")
-                    .requestMatchers(HttpMethod.GET, "/api/users/me"))
+                    .requestMatchers(
+                        HttpMethod.POST,
+                        "/api/loans/{loanProductId}",
+                        "/api/loans/{loanLedgerId}/repayment",
+                        "/api/accounts",
+                        "/api/accounts/{accountNumber}/deposit",
+                        "/api/accounts/{accountNumber}/pay",
+                        "/api/accounts/{accountNumber}/withdraw",
+                        "/api/accounts/transfer")
+                    .requestMatchers(
+                        HttpMethod.GET,
+                        "/api/users/me",
+                        "/api/accounts/{accountNumber}",
+                        "/api/accounts",
+                        "/api/accounts/{accountNumber}/transactions")
+                    .requestMatchers(HttpMethod.DELETE, "/api/accounts/{accountNumber}"))
         .authorizeHttpRequests(request -> request.anyRequest().authenticated());
 
     http.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/bank/src/main/java/com/fisa/bank/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/SecurityFilterChainConfig.java
@@ -96,31 +96,19 @@ public class SecurityFilterChainConfig {
     commonConfiguration(http);
 
     http.securityMatchers(
-        matcher ->
-            matcher
-                .requestMatchers(
-                    "/api/users",
-                    "/api/loans",
-                    "/api/interests/**",
-                    "/api/loans/products/**",
-                    "/swagger-ui/**",
-                    "/v3/api-docs/**",
-                    "/swagger-resources/**")
-                .requestMatchers(HttpMethod.GET, "/api/loans/*")
-                .requestMatchers(HttpMethod.POST, "/api/loans"));
+            matcher ->
+                matcher
+                    .requestMatchers(
+                        HttpMethod.GET,
+                        "/api/loans",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**",
+                        "/swagger-resources/**",
+                        "/api/loans/products/**",
+                        "/api/interests/**")
+                    .requestMatchers(HttpMethod.POST, "/api/loans", "/api/login", "/api/users"))
+        .authorizeHttpRequests(request -> request.anyRequest().permitAll());
 
-    http.authorizeHttpRequests(
-        auth ->
-            auth.requestMatchers(HttpMethod.POST, "/api/users")
-                .permitAll()
-                .requestMatchers(HttpMethod.POST, "/api/login")
-                .permitAll()
-                .requestMatchers("/api/loans/**")
-                .permitAll()
-                .requestMatchers("/api/interests/**")
-                .permitAll()
-                .anyRequest()
-                .permitAll());
     http.addFilterBefore(loginFilter, UsernamePasswordAuthenticationFilter.class); // login 전용 필터
     http.oauth2ResourceServer(AbstractHttpConfigurer::disable);
 
@@ -134,17 +122,16 @@ public class SecurityFilterChainConfig {
       HttpSecurity http,
       @Qualifier("authenticatedFilter") AuthenticationFilter authenticationFilter)
       throws Exception {
+
     commonConfiguration(http);
 
-    http.securityMatchers(matcher -> matcher.requestMatchers("/api/**"));
-    http.authorizeHttpRequests(
-        auth ->
-            auth.requestMatchers(HttpMethod.POST, "/api/loans/**")
-                .authenticated()
-                .requestMatchers(HttpMethod.GET, "/api/users/me")
-                .authenticated()
-                .anyRequest()
-                .authenticated());
+    http.securityMatchers(
+            matcher ->
+                matcher
+                    .requestMatchers(HttpMethod.POST, "/api/loans/**")
+                    .requestMatchers(HttpMethod.GET, "/api/users/me"))
+        .authorizeHttpRequests(request -> request.anyRequest().authenticated());
+
     http.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
     http.exceptionHandling(ex -> ex.authenticationEntryPoint(accessTokenEntryPoint));
     http.oauth2ResourceServer(AbstractHttpConfigurer::disable);
@@ -157,16 +144,8 @@ public class SecurityFilterChainConfig {
   public SecurityFilterChain loginFilterChain(HttpSecurity http) throws Exception {
 
     http.securityMatchers(
-        matcher -> matcher.requestMatchers("/login", "/default-ui.css", "/error/**"));
-    http.authorizeHttpRequests(
-        request ->
-            request
-                .requestMatchers(HttpMethod.GET, "/login")
-                .permitAll() // login
-                .requestMatchers(HttpMethod.GET, "/error/**")
-                .permitAll()
-                .requestMatchers(HttpMethod.GET, "/default-ui.css")
-                .permitAll()); // login 페이지 css
+            matcher -> matcher.requestMatchers("/login", "/default-ui.css", "/error/**"))
+        .authorizeHttpRequests(request -> request.anyRequest().permitAll());
 
     http.formLogin(Customizer.withDefaults()); // form Login 활성화
     http.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));

--- a/bank/src/main/java/com/fisa/bank/common/config/security/jwt/JwtConst.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/jwt/JwtConst.java
@@ -6,4 +6,8 @@ public class JwtConst {
   public static final String CLAIM_USER_ID = "user_id";
   public static final String CLAIM_ROLE = "role";
   public static final String CLAIM_ISSUER = "core-bank";
+
+  // Token name
+  public static final String ACCESS_TOKEN = "access_token";
+  public static final String REFRESH_TOKEN = "refresh_token";
 }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationFilter.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -16,6 +17,7 @@ import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.security.web.authentication.AuthenticationFilter;
 
 /** 사용자가 Authorization에 보낸 토큰을 추출해서 Authentication 객체로 변환하는 역할 */
+@Slf4j
 public class JwtAuthenticationFilter extends AuthenticationFilter {
 
   private final AuthenticationManager authenticationManager;
@@ -44,8 +46,11 @@ public class JwtAuthenticationFilter extends AuthenticationFilter {
           // 컨텍스트 저장
           SecurityContextHolder.getContext().setAuthentication(authentication);
         } catch (AuthenticationException e) {
-          authentication.setAuthenticated(false);
-          SecurityContextHolder.getContext().setAuthentication(authentication);
+          log.warn("인증 예외 발생 : {}", e.getMessage());
+          SecurityContextHolder.clearContext();
+        } catch (Exception e) {
+          log.warn("예상하지 못한 예외 발생 : {}", e.getMessage());
+          SecurityContextHolder.clearContext();
         }
       }
     }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationFilter.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.security.web.authentication.AuthenticationFilter;
@@ -37,11 +38,15 @@ public class JwtAuthenticationFilter extends AuthenticationFilter {
       Authentication authentication = authenticationConverter.convert(request);
 
       if (Objects.nonNull(authentication)) {
-        // 인증 진행
-        authentication = authenticationManager.authenticate(authentication);
-
-        // 컨텍스트 저장
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+        try {
+          // 인증 진행
+          authentication = authenticationManager.authenticate(authentication);
+          // 컨텍스트 저장
+          SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (AuthenticationException e) {
+          authentication.setAuthenticated(false);
+          SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
       }
     }
     filterChain.doFilter(request, response);

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/LoginSuccessHandler.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/LoginSuccessHandler.java
@@ -1,5 +1,8 @@
 package com.fisa.bank.common.config.security.resource;
 
+import static com.fisa.bank.common.config.security.jwt.JwtConst.ACCESS_TOKEN;
+import static com.fisa.bank.common.config.security.jwt.JwtConst.REFRESH_TOKEN;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -74,7 +77,7 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
   private String createBody(String accessToken, String refreshToken) {
     try {
       return objectMapper.writeValueAsString(
-          Map.of("access_token", accessToken, "refresh_token", refreshToken));
+          Map.of(ACCESS_TOKEN, accessToken, REFRESH_TOKEN, refreshToken));
     } catch (JsonProcessingException e) {
       throw new IllegalStateException("Exception occur in json processing");
     }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/NotFoundAccessTokenEntryPoint.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/NotFoundAccessTokenEntryPoint.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 // JwtAuthentication이 없을경우 실행됨 (유효한 access token이 없음)
 @Component
-public class AccessTokenEntryPoint implements AuthenticationEntryPoint {
+public class NotFoundAccessTokenEntryPoint implements AuthenticationEntryPoint {
 
   @Override
   public void commence(

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/RequiredAuthenticationEntryPoint.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/RequiredAuthenticationEntryPoint.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 // JwtAuthentication이 없을경우 실행됨 (유효한 access token이 없음)
 @Component
-public class NotFoundAccessTokenEntryPoint implements AuthenticationEntryPoint {
+public class RequiredAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
   @Override
   public void commence(


### PR DESCRIPTION
closes #41 
### 필터 체인 설정 간소화
- `securityMatchers()`만 사용해서 필터체인에 매칭되는 엔드포인트들을 거르고,
    인가 설정은 `permitAll()` 또는 `authenticated()`를 통해서 수행하도록 수정하였습니다.
- 이전보다 조금 더 쉽게 필터체인 설정을 구성할 수 있습니다.