### PR TITLE
[FIX] 원금 균등 상환 계산 결과 조정

### DIFF
--- a/bank/src/main/java/com/fisa/bank/loan/application/service/EqualPrincipalCalculator.java
+++ b/bank/src/main/java/com/fisa/bank/loan/application/service/EqualPrincipalCalculator.java
@@ -46,11 +46,12 @@ public class EqualPrincipalCalculator implements LoanCalculator {
     // 첫 상환일에 원금을 가장 많이 내도록 조정
     BigDecimal monthlyPrincipal =
         principal.divide(BigDecimal.valueOf(totalTermInMonths), 0, RoundingMode.DOWN);
-    if (currentTerm == 1) {
+    boolean isFirstRepayment = remainPrincipal.compareTo(principal) == 0;
+
+    if (isFirstRepayment) {
       principalPayment =
           remainPrincipal.subtract(
               monthlyPrincipal.multiply(BigDecimal.valueOf(totalTermInMonths - 1)));
-      currentTerm++;
     } else {
       // 2회차 이후는 기존 균등 원금 상환
       principalPayment = monthlyPrincipal;

--- a/bank/src/main/java/com/fisa/bank/loan/application/service/EqualPrincipalCalculator.java
+++ b/bank/src/main/java/com/fisa/bank/loan/application/service/EqualPrincipalCalculator.java
@@ -3,15 +3,10 @@ package com.fisa.bank.loan.application.service;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 
 import com.fisa.bank.loan.application.model.MonthlyRepayment;
 
-/*
-   원금 균등 상환 - 월별 상환액 계산기
-   P - 대출 원금
-   r - 월 이자율(금리)
-   N - 총 상환 횟수(개월)
-*/
 public class EqualPrincipalCalculator implements LoanCalculator {
 
   private static final EqualPrincipalCalculator INSTANCE = new EqualPrincipalCalculator();
@@ -32,29 +27,36 @@ public class EqualPrincipalCalculator implements LoanCalculator {
       LocalDateTime nextRepaymentDate,
       LocalDateTime loanEndDate) {
 
-    // 월 이자율 계산 (연 이자율 / 12)
-    BigDecimal monthlyRate =
-        annualInterestRate.divide(BigDecimal.valueOf(12), 10, RoundingMode.HALF_DOWN);
+    int month = nextRepaymentDate.getMonthValue();
+    int year = nextRepaymentDate.getYear();
+    int daysInMonth = YearMonth.of(year, month).lengthOfMonth();
+
+    BigDecimal interestPayment =
+        remainPrincipal
+            .multiply(annualInterestRate)
+            .multiply(BigDecimal.valueOf(daysInMonth))
+            .divide(
+                BigDecimal.valueOf(nextRepaymentDate.toLocalDate().lengthOfYear()),
+                0,
+                RoundingMode.DOWN);
 
     // 매월 동일한 원금 상환액 = 총 원금 / 총 상환 기간
-    BigDecimal monthlyPrincipalPayment =
-        principal.divide(BigDecimal.valueOf(totalTermInMonths), 0, RoundingMode.DOWN);
-
-    // 해당 월의 이자 = 남은 원금 * 월 이자율
-    BigDecimal interestPayment =
-        remainPrincipal.multiply(monthlyRate).setScale(0, RoundingMode.DOWN);
-
     BigDecimal principalPayment;
-    BigDecimal monthlyPayment;
 
-    // 다음 상환 날짜와 마지막 상환 날짜가 같다면 마지막 상환일이므로, 갚아야 하는 원금을 남은 원금으로 치환.
-    if (nextRepaymentDate.toLocalDate().equals(loanEndDate.toLocalDate())) {
-      principalPayment = remainPrincipal.setScale(0, RoundingMode.UP);
-      monthlyPayment = principalPayment.add(interestPayment);
+    // 첫 상환일에 원금을 가장 많이 내도록 조정
+    BigDecimal monthlyPrincipal =
+        principal.divide(BigDecimal.valueOf(totalTermInMonths), 0, RoundingMode.DOWN);
+    if (currentTerm == 1) {
+      principalPayment =
+          remainPrincipal.subtract(
+              monthlyPrincipal.multiply(BigDecimal.valueOf(totalTermInMonths - 1)));
+      currentTerm++;
     } else {
-      principalPayment = monthlyPrincipalPayment;
-      monthlyPayment = principalPayment.add(interestPayment);
+      // 2회차 이후는 기존 균등 원금 상환
+      principalPayment = monthlyPrincipal;
     }
+
+    BigDecimal monthlyPayment = principalPayment.add(interestPayment);
 
     return new MonthlyRepayment(
         currentTerm,

--- a/bank/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/bank/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -317,7 +317,7 @@ public class LoanService {
         loanLedger.getRemainPrincipal(),
         loanLedger.getCompletedInterest().divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP),
         loanLedger.getTerm() * 12, // 연 -> 개월로 변경
-        0, // currentTerm은 실제로 사용되지 않음
+        1, // currentTerm은 실제로 사용되지 않음
         loanLedger.getNextRepaymentDate(),
         loanLedger.getLoanEndDate());
   }

--- a/bank/src/test/java/com/fisa/bank/loan/application/service/EqualPrincipalCalculatorTest.java
+++ b/bank/src/test/java/com/fisa/bank/loan/application/service/EqualPrincipalCalculatorTest.java
@@ -16,8 +16,8 @@ public class EqualPrincipalCalculatorTest {
     BigDecimal annualInterestRate = BigDecimal.valueOf(0.05); // 연이율 5%
     int totalTermInMonths = 12; // 12개월
 
-    LocalDateTime nextRepaymentDate = LocalDateTime.of(2025, 12, 3, 17, 9, 30); // 첫 상환일
-    LocalDateTime loanEndDate = LocalDateTime.of(2026, 11, 3, 17, 9, 30); // 마지막 상환일
+    LocalDateTime nextRepaymentDate = LocalDateTime.of(2025, 11, 3, 17, 9, 30); // 첫 상환일
+    LocalDateTime loanEndDate = LocalDateTime.of(2026, 10, 3, 17, 9, 30); // 마지막 상환일
 
     BigDecimal remainPrincipal = principal;
 


### PR DESCRIPTION
## 📌 관련 이슈
- #59 

## ✒️ 작업 내용
- 원금 균등 상환 계산 결과 오차 조정했습니다.
 : 첫 상환일에 가장 많은 원금을 지불하도록 조건문 추가
 : 연 금리 5%, 원금 1000000원, 상환 기간 12개월로 테스트
 : 우리은행 금융계산기와 비교하여 RoundingMode, Scale 조정

### 스크린샷 🏞️ (선택)

## 💬 REVIEWER에게 요구사항 💬 