### PR TITLE
[FEAT] 테스트 환경 시큐리티 체인 설정

### DIFF
--- a/bank/src/main/java/com/fisa/bank/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/SecurityFilterChainConfig.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpMethod;
@@ -29,6 +30,7 @@ import com.fisa.bank.common.config.security.resource.UnknownEndPointFilter;
 
 @Configuration
 @RequiredArgsConstructor
+@Profile({"local", "prod", "dev"})
 public class SecurityFilterChainConfig {
 
   private final RequiredAuthenticationEntryPoint requiredAuthenticationEntryPoint;

--- a/bank/src/main/java/com/fisa/bank/common/config/security/TestSecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/TestSecurityFilterChainConfig.java
@@ -1,27 +1,59 @@
 package com.fisa.bank.common.config.security;
 
+import com.fisa.bank.common.config.security.resource.UnknownEndPointFilter;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.server.authorization.config.annotation.web.configurers.OAuth2AuthorizationServerConfigurer;
+import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenGenerator;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationFilter;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.session.DisableEncodeUrlFilter;
 
 @Profile({"test"})
 @Configuration
 @RequiredArgsConstructor
 public class TestSecurityFilterChainConfig {
 
+    @Bean
+    @Order(1)
+    // Authorization Server 필터 체인 설정
+    public SecurityFilterChain authorizationServerSecurityFilterChain(
+            HttpSecurity http, OAuth2TokenGenerator<?> tokenGenerator)
+            throws Exception {
+        OAuth2AuthorizationServerConfigurer authorizationServer =
+                OAuth2AuthorizationServerConfigurer.authorizationServer();
+
+        //    commonConfiguration(http); // 공통 설정
+        http.formLogin(Customizer.withDefaults());
+        http.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
+        http.csrf(AbstractHttpConfigurer::disable);
+        // SAS 엔드포인트만 매칭
+
+        http.securityMatcher(authorizationServer.getEndpointsMatcher())
+                .authorizeHttpRequests(auth ->auth.anyRequest().permitAll());
+
+        // SAS 기능 활성화(OIDC 포함)
+        http.with(authorizationServer, as -> as.tokenGenerator(tokenGenerator).oidc(Customizer.withDefaults()));
+        // 인증 안 된 HTML 요청은 /login으로
+        http.exceptionHandling(Customizer.withDefaults());
+        http.oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+
+        return http.build();
+    }
+
   /** 테스트 환경에서 임시 토큰을 발급 받기 위한 시큐리티 필터 체인 무조건 로그인에 성공하며, 토큰이 발급된다. */
   @Bean
-  @Order(1)
+  @Order(2)
   public SecurityFilterChain login(
       @Qualifier("TestLoginAuthenticationFilter") AuthenticationFilter loginFilter,
       HttpSecurity http)
@@ -40,7 +72,7 @@ public class TestSecurityFilterChainConfig {
 
   /** 테스트 환경에서 AccessToken을 받는 엔드포인트 액세스 토큰이 있든 없든 통과한다. */
   @Bean
-  @Order(2)
+  @Order(3)
   public SecurityFilterChain api(
       @Qualifier("TestJwtAuthenticationFilter") AuthenticationFilter authenticationFilter,
       HttpSecurity http)

--- a/bank/src/main/java/com/fisa/bank/common/config/security/TestSecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/TestSecurityFilterChainConfig.java
@@ -1,0 +1,70 @@
+package com.fisa.bank.common.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFilter;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Profile({"test"})
+@Configuration
+@RequiredArgsConstructor
+public class TestSecurityFilterChainConfig {
+
+    /**
+     * 테스트 환경에서 임시 토큰을 발급 받기 위한 시큐리티 필터 체인
+     * 무조건 로그인에 성공하며, 토큰이 발급된다.
+     */
+    @Bean
+    @Order(1)
+    public SecurityFilterChain login(
+            @Qualifier("TestLoginAuthenticationFilter")AuthenticationFilter loginFilter,
+            HttpSecurity http
+            ) throws Exception{
+        commonConfigurations(http);
+
+        http.securityMatchers(matcher -> {
+                    matcher.requestMatchers(HttpMethod.POST, "/api/login/{userId}");
+                }
+        ).authorizeHttpRequests(request -> request.anyRequest().permitAll());
+        http.addFilterBefore(loginFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    /**
+     * 테스트 환경에서 AccessToken을 받는 엔드포인트
+     * 액세스 토큰이 있든 없든 통과한다.
+     */
+    @Bean
+    @Order(2)
+    public SecurityFilterChain api(
+            @Qualifier("TestJwtAuthenticationFilter") AuthenticationFilter authenticationFilter,
+            HttpSecurity http
+    ) throws Exception{
+        commonConfigurations(http);
+
+        http.securityMatchers(matcher -> matcher.requestMatchers("/api/**"))
+                .authorizeHttpRequests(request -> request.anyRequest().authenticated());
+
+        http.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    public void commonConfigurations(HttpSecurity http) throws Exception{
+        http.csrf(AbstractHttpConfigurer::disable);
+        http.formLogin(AbstractHttpConfigurer::disable);
+        http.sessionManagement(AbstractHttpConfigurer::disable);
+        http.httpBasic(AbstractHttpConfigurer::disable);
+        http.logout(AbstractHttpConfigurer::disable);
+    }
+
+}

--- a/bank/src/main/java/com/fisa/bank/common/config/security/TestSecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/TestSecurityFilterChainConfig.java
@@ -1,7 +1,7 @@
 package com.fisa.bank.common.config.security;
 
-import com.fisa.bank.common.config.security.resource.UnknownEndPointFilter;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,39 +17,39 @@ import org.springframework.security.oauth2.server.authorization.token.OAuth2Toke
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationFilter;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.session.DisableEncodeUrlFilter;
 
 @Profile({"test"})
 @Configuration
 @RequiredArgsConstructor
 public class TestSecurityFilterChainConfig {
 
-    @Bean
-    @Order(1)
-    // Authorization Server 필터 체인 설정
-    public SecurityFilterChain authorizationServerSecurityFilterChain(
-            HttpSecurity http, OAuth2TokenGenerator<?> tokenGenerator)
-            throws Exception {
-        OAuth2AuthorizationServerConfigurer authorizationServer =
-                OAuth2AuthorizationServerConfigurer.authorizationServer();
+  @Bean
+  @Order(1)
+  // Authorization Server 필터 체인 설정
+  public SecurityFilterChain authorizationServerSecurityFilterChain(
+      HttpSecurity http, OAuth2TokenGenerator<?> tokenGenerator) throws Exception {
+    OAuth2AuthorizationServerConfigurer authorizationServer =
+        OAuth2AuthorizationServerConfigurer.authorizationServer();
 
-        //    commonConfiguration(http); // 공통 설정
-        http.formLogin(Customizer.withDefaults());
-        http.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
-        http.csrf(AbstractHttpConfigurer::disable);
-        // SAS 엔드포인트만 매칭
+    //    commonConfiguration(http); // 공통 설정
+    http.formLogin(Customizer.withDefaults());
+    http.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
+    http.csrf(AbstractHttpConfigurer::disable);
+    // SAS 엔드포인트만 매칭
 
-        http.securityMatcher(authorizationServer.getEndpointsMatcher())
-                .authorizeHttpRequests(auth ->auth.anyRequest().permitAll());
+    http.securityMatcher(authorizationServer.getEndpointsMatcher())
+        .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
 
-        // SAS 기능 활성화(OIDC 포함)
-        http.with(authorizationServer, as -> as.tokenGenerator(tokenGenerator).oidc(Customizer.withDefaults()));
-        // 인증 안 된 HTML 요청은 /login으로
-        http.exceptionHandling(Customizer.withDefaults());
-        http.oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+    // SAS 기능 활성화(OIDC 포함)
+    http.with(
+        authorizationServer,
+        as -> as.tokenGenerator(tokenGenerator).oidc(Customizer.withDefaults()));
+    // 인증 안 된 HTML 요청은 /login으로
+    http.exceptionHandling(Customizer.withDefaults());
+    http.oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
 
-        return http.build();
-    }
+    return http.build();
+  }
 
   /** 테스트 환경에서 임시 토큰을 발급 받기 위한 시큐리티 필터 체인 무조건 로그인에 성공하며, 토큰이 발급된다. */
   @Bean

--- a/bank/src/main/java/com/fisa/bank/common/config/security/TestSecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/TestSecurityFilterChainConfig.java
@@ -31,12 +31,11 @@ public class TestSecurityFilterChainConfig {
     OAuth2AuthorizationServerConfigurer authorizationServer =
         OAuth2AuthorizationServerConfigurer.authorizationServer();
 
-    //    commonConfiguration(http); // 공통 설정
     http.formLogin(Customizer.withDefaults());
     http.sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED));
     http.csrf(AbstractHttpConfigurer::disable);
-    // SAS 엔드포인트만 매칭
 
+    // SAS 엔드포인트만 매칭
     http.securityMatcher(authorizationServer.getEndpointsMatcher())
         .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
 
@@ -44,7 +43,7 @@ public class TestSecurityFilterChainConfig {
     http.with(
         authorizationServer,
         as -> as.tokenGenerator(tokenGenerator).oidc(Customizer.withDefaults()));
-    // 인증 안 된 HTML 요청은 /login으로
+
     http.exceptionHandling(Customizer.withDefaults());
     http.oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
 

--- a/bank/src/main/java/com/fisa/bank/common/config/security/TestSecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/TestSecurityFilterChainConfig.java
@@ -1,6 +1,7 @@
 package com.fisa.bank.common.config.security;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,53 +19,47 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class TestSecurityFilterChainConfig {
 
-    /**
-     * 테스트 환경에서 임시 토큰을 발급 받기 위한 시큐리티 필터 체인
-     * 무조건 로그인에 성공하며, 토큰이 발급된다.
-     */
-    @Bean
-    @Order(1)
-    public SecurityFilterChain login(
-            @Qualifier("TestLoginAuthenticationFilter")AuthenticationFilter loginFilter,
-            HttpSecurity http
-            ) throws Exception{
-        commonConfigurations(http);
+  /** 테스트 환경에서 임시 토큰을 발급 받기 위한 시큐리티 필터 체인 무조건 로그인에 성공하며, 토큰이 발급된다. */
+  @Bean
+  @Order(1)
+  public SecurityFilterChain login(
+      @Qualifier("TestLoginAuthenticationFilter") AuthenticationFilter loginFilter,
+      HttpSecurity http)
+      throws Exception {
+    commonConfigurations(http);
 
-        http.securityMatchers(matcher -> {
-                    matcher.requestMatchers(HttpMethod.POST, "/api/login/{userId}");
-                }
-        ).authorizeHttpRequests(request -> request.anyRequest().permitAll());
-        http.addFilterBefore(loginFilter, UsernamePasswordAuthenticationFilter.class);
+    http.securityMatchers(
+            matcher -> {
+              matcher.requestMatchers(HttpMethod.POST, "/api/login/{userId}");
+            })
+        .authorizeHttpRequests(request -> request.anyRequest().permitAll());
+    http.addFilterBefore(loginFilter, UsernamePasswordAuthenticationFilter.class);
 
-        return http.build();
-    }
+    return http.build();
+  }
 
-    /**
-     * 테스트 환경에서 AccessToken을 받는 엔드포인트
-     * 액세스 토큰이 있든 없든 통과한다.
-     */
-    @Bean
-    @Order(2)
-    public SecurityFilterChain api(
-            @Qualifier("TestJwtAuthenticationFilter") AuthenticationFilter authenticationFilter,
-            HttpSecurity http
-    ) throws Exception{
-        commonConfigurations(http);
+  /** 테스트 환경에서 AccessToken을 받는 엔드포인트 액세스 토큰이 있든 없든 통과한다. */
+  @Bean
+  @Order(2)
+  public SecurityFilterChain api(
+      @Qualifier("TestJwtAuthenticationFilter") AuthenticationFilter authenticationFilter,
+      HttpSecurity http)
+      throws Exception {
+    commonConfigurations(http);
 
-        http.securityMatchers(matcher -> matcher.requestMatchers("/api/**"))
-                .authorizeHttpRequests(request -> request.anyRequest().authenticated());
+    http.securityMatchers(matcher -> matcher.requestMatchers("/api/**"))
+        .authorizeHttpRequests(request -> request.anyRequest().authenticated());
 
-        http.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    http.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
-        return http.build();
-    }
+    return http.build();
+  }
 
-    public void commonConfigurations(HttpSecurity http) throws Exception{
-        http.csrf(AbstractHttpConfigurer::disable);
-        http.formLogin(AbstractHttpConfigurer::disable);
-        http.sessionManagement(AbstractHttpConfigurer::disable);
-        http.httpBasic(AbstractHttpConfigurer::disable);
-        http.logout(AbstractHttpConfigurer::disable);
-    }
-
+  public void commonConfigurations(HttpSecurity http) throws Exception {
+    http.csrf(AbstractHttpConfigurer::disable);
+    http.formLogin(AbstractHttpConfigurer::disable);
+    http.sessionManagement(AbstractHttpConfigurer::disable);
+    http.httpBasic(AbstractHttpConfigurer::disable);
+    http.logout(AbstractHttpConfigurer::disable);
+  }
 }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestAuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestAuthorizationConfig.java
@@ -1,0 +1,129 @@
+package com.fisa.bank.common.config.security.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fisa.bank.common.config.security.jwt.UserJwtGenerator;
+import com.fisa.bank.common.config.security.resource.JwtAuthenticationConverter;
+import com.fisa.bank.common.config.security.resource.LoginFailureHandler;
+import com.fisa.bank.common.config.security.resource.LoginSuccessHandler;
+import com.fisa.bank.common.config.security.resource.UnknownEndPointFilter;
+import com.fisa.bank.user.persistence.repository.UserAuthRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationFilter;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+@Profile({"test"})
+@Configuration
+@RequiredArgsConstructor
+public class TestAuthorizationConfig {
+
+    // Spring Security 의 AuthenticationManger 등록
+    @Bean
+    AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+
+    @Bean("TestLoginAuthenticationFilter")
+    public AuthenticationFilter testLoginFilter(
+        AuthenticationManager authenticationManager,
+        @Qualifier("LoginFailureHandler") AuthenticationFailureHandler failureHandler,
+        @Qualifier("LoginSuccessHandler") AuthenticationSuccessHandler successHandler,
+        @Qualifier("TestUsernamePasswordConverter") AuthenticationConverter authenticationConverter
+    ){
+        AuthenticationFilter authenticationFilter = new TestLoginAuthenticationFilter(authenticationManager, authenticationConverter);
+
+        RequestMatcher requestMatcher =
+                PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/api/login/{userId}");
+
+        authenticationFilter.setRequestMatcher(requestMatcher);
+        authenticationFilter.setFailureHandler(failureHandler);
+        authenticationFilter.setSuccessHandler(successHandler);
+
+        return authenticationFilter;
+    }
+
+    @Bean("TestJwtAuthenticationFilter")
+    public AuthenticationFilter testJwtFilter(
+            @Qualifier("UsernamePasswordAuthenticationProvider") AuthenticationProvider authenticationProvider,
+            @Qualifier("TestAuthenticationConverter") AuthenticationConverter authenticationConverter
+    ){
+        AuthenticationManager authenticationManager = new ProviderManager(authenticationProvider);
+        AuthenticationFilter authenticationFilter = new TestJwtAuthenticationFilter(authenticationManager, authenticationConverter);
+
+        RequestMatcher requestMatcher =
+                PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/**");
+
+        authenticationFilter.setRequestMatcher(requestMatcher);
+
+        return authenticationFilter;
+    }
+
+    @Bean("UsernamePasswordAuthenticationProvider")
+    public AuthenticationProvider usernameProvider(){
+        return new TestUsernamePasswordAuthenticationProvider();
+    }
+
+    @Bean("LoginFailureHandler")
+    public AuthenticationFailureHandler loginFailureHandler(ObjectMapper om){
+        return new LoginFailureHandler(om);
+    }
+
+    @Bean("LoginSuccessHandler")
+    public AuthenticationSuccessHandler loginSuccessHandler(
+            ObjectMapper objectMapper,
+            UserJwtGenerator jwtGenerator
+    ){
+        return new TestLoginSuccessHandler(jwtGenerator, objectMapper);
+    }
+
+    @Bean("TestAuthenticationConverter")
+    public AuthenticationConverter authenticationConverter(){
+        return new JwtAuthenticationConverter();
+    }
+
+    @Bean("PasswordEncoder")
+    public PasswordEncoder passwordEncoder(){
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @Bean("UserDetailsService")
+    public UserDetailsService userDetailsService(){
+        return new TestUserDetailsService();
+    }
+
+    /** 로그인 전용 필터 서블릿 필터에서 제외 */
+    @Bean
+    public FilterRegistrationBean<AuthenticationFilter> loginFilterRegistrationBean(
+            @Qualifier("TestLoginAuthenticationFilter") AuthenticationFilter authenticationFilter) {
+        FilterRegistrationBean<AuthenticationFilter> registrationBean =
+                new FilterRegistrationBean<>(authenticationFilter);
+        registrationBean.setEnabled(false); // 서블릿 필터에서 제거
+        return registrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean<UnknownEndPointFilter> unknownFilterRegistrationBean(
+            UnknownEndPointFilter unknownEndPointFilter) {
+        FilterRegistrationBean<UnknownEndPointFilter> registrationBean =
+                new FilterRegistrationBean<>(unknownEndPointFilter);
+        registrationBean.setEnabled(false); // 서블릿 필터에서 제거
+        return registrationBean;
+    }
+
+}

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestAuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestAuthorizationConfig.java
@@ -1,5 +1,6 @@
 package com.fisa.bank.common.config.security.mock;
 
+import com.fisa.bank.common.config.security.resource.JwtAuthenticationProvider;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -15,6 +16,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationFilter;
@@ -41,12 +43,12 @@ public class TestAuthorizationConfig {
 
   @Bean("TestLoginAuthenticationFilter")
   public AuthenticationFilter testLoginFilter(
-      AuthenticationManager authenticationManager,
-      @Qualifier("LoginFailureHandler") AuthenticationFailureHandler failureHandler,
-      @Qualifier("LoginSuccessHandler") AuthenticationSuccessHandler successHandler,
+      @Qualifier("TestUsernamePasswordAuthenticationProvider") AuthenticationProvider authenticationProvider,
+      @Qualifier("TestLoginFailureHandler") AuthenticationFailureHandler failureHandler,
+      @Qualifier("TestLoginSuccessHandler") AuthenticationSuccessHandler successHandler,
       @Qualifier("TestUsernamePasswordConverter") AuthenticationConverter authenticationConverter) {
     AuthenticationFilter authenticationFilter =
-        new TestLoginAuthenticationFilter(authenticationManager, authenticationConverter);
+        new TestLoginAuthenticationFilter(new ProviderManager(authenticationProvider), authenticationConverter);
 
     RequestMatcher requestMatcher =
         PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/api/login/{userId}");
@@ -60,7 +62,7 @@ public class TestAuthorizationConfig {
 
   @Bean("TestJwtAuthenticationFilter")
   public AuthenticationFilter testJwtFilter(
-      @Qualifier("UsernamePasswordAuthenticationProvider")
+      @Qualifier("TestJwtAuthenticationProvider")
           AuthenticationProvider authenticationProvider,
       @Qualifier("TestAuthenticationConverter") AuthenticationConverter authenticationConverter) {
     AuthenticationManager authenticationManager = new ProviderManager(authenticationProvider);
@@ -68,24 +70,29 @@ public class TestAuthorizationConfig {
         new TestJwtAuthenticationFilter(authenticationManager, authenticationConverter);
 
     RequestMatcher requestMatcher =
-        PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/**");
+        PathPatternRequestMatcher.withDefaults().matcher("/**");
 
     authenticationFilter.setRequestMatcher(requestMatcher);
 
     return authenticationFilter;
   }
 
-  @Bean("UsernamePasswordAuthenticationProvider")
+  @Bean("TestJwtAuthenticationProvider")
+  public AuthenticationProvider jwtAuthenticationProvider(JwtDecoder jwtDecoder){
+      return new JwtAuthenticationProvider(jwtDecoder);
+  }
+
+  @Bean("TestUsernamePasswordAuthenticationProvider")
   public AuthenticationProvider usernameProvider() {
     return new TestUsernamePasswordAuthenticationProvider();
   }
 
-  @Bean("LoginFailureHandler")
+  @Bean("TestLoginFailureHandler")
   public AuthenticationFailureHandler loginFailureHandler(ObjectMapper om) {
     return new LoginFailureHandler(om);
   }
 
-  @Bean("LoginSuccessHandler")
+  @Bean("TestLoginSuccessHandler")
   public AuthenticationSuccessHandler loginSuccessHandler(
       ObjectMapper objectMapper, UserJwtGenerator jwtGenerator) {
     return new TestLoginSuccessHandler(jwtGenerator, objectMapper);
@@ -96,12 +103,12 @@ public class TestAuthorizationConfig {
     return new JwtAuthenticationConverter();
   }
 
-  @Bean("PasswordEncoder")
+  @Bean("TestPasswordEncoder")
   public PasswordEncoder passwordEncoder() {
     return PasswordEncoderFactories.createDelegatingPasswordEncoder();
   }
 
-  @Bean("UserDetailsService")
+  @Bean("TestUserDetailsService")
   public UserDetailsService userDetailsService() {
     return new TestUserDetailsService();
   }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestAuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestAuthorizationConfig.java
@@ -1,6 +1,5 @@
 package com.fisa.bank.common.config.security.mock;
 
-import com.fisa.bank.common.config.security.resource.JwtAuthenticationProvider;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -27,6 +26,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fisa.bank.common.config.security.jwt.UserJwtGenerator;
 import com.fisa.bank.common.config.security.resource.JwtAuthenticationConverter;
+import com.fisa.bank.common.config.security.resource.JwtAuthenticationProvider;
 import com.fisa.bank.common.config.security.resource.LoginFailureHandler;
 import com.fisa.bank.common.config.security.resource.UnknownEndPointFilter;
 
@@ -43,12 +43,14 @@ public class TestAuthorizationConfig {
 
   @Bean("TestLoginAuthenticationFilter")
   public AuthenticationFilter testLoginFilter(
-      @Qualifier("TestUsernamePasswordAuthenticationProvider") AuthenticationProvider authenticationProvider,
+      @Qualifier("TestUsernamePasswordAuthenticationProvider")
+          AuthenticationProvider authenticationProvider,
       @Qualifier("TestLoginFailureHandler") AuthenticationFailureHandler failureHandler,
       @Qualifier("TestLoginSuccessHandler") AuthenticationSuccessHandler successHandler,
       @Qualifier("TestUsernamePasswordConverter") AuthenticationConverter authenticationConverter) {
     AuthenticationFilter authenticationFilter =
-        new TestLoginAuthenticationFilter(new ProviderManager(authenticationProvider), authenticationConverter);
+        new TestLoginAuthenticationFilter(
+            new ProviderManager(authenticationProvider), authenticationConverter);
 
     RequestMatcher requestMatcher =
         PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/api/login/{userId}");
@@ -62,15 +64,13 @@ public class TestAuthorizationConfig {
 
   @Bean("TestJwtAuthenticationFilter")
   public AuthenticationFilter testJwtFilter(
-      @Qualifier("TestJwtAuthenticationProvider")
-          AuthenticationProvider authenticationProvider,
+      @Qualifier("TestJwtAuthenticationProvider") AuthenticationProvider authenticationProvider,
       @Qualifier("TestAuthenticationConverter") AuthenticationConverter authenticationConverter) {
     AuthenticationManager authenticationManager = new ProviderManager(authenticationProvider);
     AuthenticationFilter authenticationFilter =
         new TestJwtAuthenticationFilter(authenticationManager, authenticationConverter);
 
-    RequestMatcher requestMatcher =
-        PathPatternRequestMatcher.withDefaults().matcher("/**");
+    RequestMatcher requestMatcher = PathPatternRequestMatcher.withDefaults().matcher("/**");
 
     authenticationFilter.setRequestMatcher(requestMatcher);
 
@@ -78,8 +78,8 @@ public class TestAuthorizationConfig {
   }
 
   @Bean("TestJwtAuthenticationProvider")
-  public AuthenticationProvider jwtAuthenticationProvider(JwtDecoder jwtDecoder){
-      return new JwtAuthenticationProvider(jwtDecoder);
+  public AuthenticationProvider jwtAuthenticationProvider(JwtDecoder jwtDecoder) {
+    return new JwtAuthenticationProvider(jwtDecoder);
   }
 
   @Bean("TestUsernamePasswordAuthenticationProvider")

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestAuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestAuthorizationConfig.java
@@ -1,13 +1,7 @@
 package com.fisa.bank.common.config.security.mock;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fisa.bank.common.config.security.jwt.UserJwtGenerator;
-import com.fisa.bank.common.config.security.resource.JwtAuthenticationConverter;
-import com.fisa.bank.common.config.security.resource.LoginFailureHandler;
-import com.fisa.bank.common.config.security.resource.LoginSuccessHandler;
-import com.fisa.bank.common.config.security.resource.UnknownEndPointFilter;
-import com.fisa.bank.user.persistence.repository.UserAuthRepository;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -28,102 +22,106 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fisa.bank.common.config.security.jwt.UserJwtGenerator;
+import com.fisa.bank.common.config.security.resource.JwtAuthenticationConverter;
+import com.fisa.bank.common.config.security.resource.LoginFailureHandler;
+import com.fisa.bank.common.config.security.resource.UnknownEndPointFilter;
+
 @Profile({"test"})
 @Configuration
 @RequiredArgsConstructor
 public class TestAuthorizationConfig {
 
-    // Spring Security 의 AuthenticationManger 등록
-    @Bean
-    AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
-        return config.getAuthenticationManager();
-    }
+  // Spring Security 의 AuthenticationManger 등록
+  @Bean
+  AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+    return config.getAuthenticationManager();
+  }
 
-    @Bean("TestLoginAuthenticationFilter")
-    public AuthenticationFilter testLoginFilter(
-        AuthenticationManager authenticationManager,
-        @Qualifier("LoginFailureHandler") AuthenticationFailureHandler failureHandler,
-        @Qualifier("LoginSuccessHandler") AuthenticationSuccessHandler successHandler,
-        @Qualifier("TestUsernamePasswordConverter") AuthenticationConverter authenticationConverter
-    ){
-        AuthenticationFilter authenticationFilter = new TestLoginAuthenticationFilter(authenticationManager, authenticationConverter);
+  @Bean("TestLoginAuthenticationFilter")
+  public AuthenticationFilter testLoginFilter(
+      AuthenticationManager authenticationManager,
+      @Qualifier("LoginFailureHandler") AuthenticationFailureHandler failureHandler,
+      @Qualifier("LoginSuccessHandler") AuthenticationSuccessHandler successHandler,
+      @Qualifier("TestUsernamePasswordConverter") AuthenticationConverter authenticationConverter) {
+    AuthenticationFilter authenticationFilter =
+        new TestLoginAuthenticationFilter(authenticationManager, authenticationConverter);
 
-        RequestMatcher requestMatcher =
-                PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/api/login/{userId}");
+    RequestMatcher requestMatcher =
+        PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/api/login/{userId}");
 
-        authenticationFilter.setRequestMatcher(requestMatcher);
-        authenticationFilter.setFailureHandler(failureHandler);
-        authenticationFilter.setSuccessHandler(successHandler);
+    authenticationFilter.setRequestMatcher(requestMatcher);
+    authenticationFilter.setFailureHandler(failureHandler);
+    authenticationFilter.setSuccessHandler(successHandler);
 
-        return authenticationFilter;
-    }
+    return authenticationFilter;
+  }
 
-    @Bean("TestJwtAuthenticationFilter")
-    public AuthenticationFilter testJwtFilter(
-            @Qualifier("UsernamePasswordAuthenticationProvider") AuthenticationProvider authenticationProvider,
-            @Qualifier("TestAuthenticationConverter") AuthenticationConverter authenticationConverter
-    ){
-        AuthenticationManager authenticationManager = new ProviderManager(authenticationProvider);
-        AuthenticationFilter authenticationFilter = new TestJwtAuthenticationFilter(authenticationManager, authenticationConverter);
+  @Bean("TestJwtAuthenticationFilter")
+  public AuthenticationFilter testJwtFilter(
+      @Qualifier("UsernamePasswordAuthenticationProvider")
+          AuthenticationProvider authenticationProvider,
+      @Qualifier("TestAuthenticationConverter") AuthenticationConverter authenticationConverter) {
+    AuthenticationManager authenticationManager = new ProviderManager(authenticationProvider);
+    AuthenticationFilter authenticationFilter =
+        new TestJwtAuthenticationFilter(authenticationManager, authenticationConverter);
 
-        RequestMatcher requestMatcher =
-                PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/**");
+    RequestMatcher requestMatcher =
+        PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/**");
 
-        authenticationFilter.setRequestMatcher(requestMatcher);
+    authenticationFilter.setRequestMatcher(requestMatcher);
 
-        return authenticationFilter;
-    }
+    return authenticationFilter;
+  }
 
-    @Bean("UsernamePasswordAuthenticationProvider")
-    public AuthenticationProvider usernameProvider(){
-        return new TestUsernamePasswordAuthenticationProvider();
-    }
+  @Bean("UsernamePasswordAuthenticationProvider")
+  public AuthenticationProvider usernameProvider() {
+    return new TestUsernamePasswordAuthenticationProvider();
+  }
 
-    @Bean("LoginFailureHandler")
-    public AuthenticationFailureHandler loginFailureHandler(ObjectMapper om){
-        return new LoginFailureHandler(om);
-    }
+  @Bean("LoginFailureHandler")
+  public AuthenticationFailureHandler loginFailureHandler(ObjectMapper om) {
+    return new LoginFailureHandler(om);
+  }
 
-    @Bean("LoginSuccessHandler")
-    public AuthenticationSuccessHandler loginSuccessHandler(
-            ObjectMapper objectMapper,
-            UserJwtGenerator jwtGenerator
-    ){
-        return new TestLoginSuccessHandler(jwtGenerator, objectMapper);
-    }
+  @Bean("LoginSuccessHandler")
+  public AuthenticationSuccessHandler loginSuccessHandler(
+      ObjectMapper objectMapper, UserJwtGenerator jwtGenerator) {
+    return new TestLoginSuccessHandler(jwtGenerator, objectMapper);
+  }
 
-    @Bean("TestAuthenticationConverter")
-    public AuthenticationConverter authenticationConverter(){
-        return new JwtAuthenticationConverter();
-    }
+  @Bean("TestAuthenticationConverter")
+  public AuthenticationConverter authenticationConverter() {
+    return new JwtAuthenticationConverter();
+  }
 
-    @Bean("PasswordEncoder")
-    public PasswordEncoder passwordEncoder(){
-        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
-    }
+  @Bean("PasswordEncoder")
+  public PasswordEncoder passwordEncoder() {
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+  }
 
-    @Bean("UserDetailsService")
-    public UserDetailsService userDetailsService(){
-        return new TestUserDetailsService();
-    }
+  @Bean("UserDetailsService")
+  public UserDetailsService userDetailsService() {
+    return new TestUserDetailsService();
+  }
 
-    /** 로그인 전용 필터 서블릿 필터에서 제외 */
-    @Bean
-    public FilterRegistrationBean<AuthenticationFilter> loginFilterRegistrationBean(
-            @Qualifier("TestLoginAuthenticationFilter") AuthenticationFilter authenticationFilter) {
-        FilterRegistrationBean<AuthenticationFilter> registrationBean =
-                new FilterRegistrationBean<>(authenticationFilter);
-        registrationBean.setEnabled(false); // 서블릿 필터에서 제거
-        return registrationBean;
-    }
+  /** 로그인 전용 필터 서블릿 필터에서 제외 */
+  @Bean
+  public FilterRegistrationBean<AuthenticationFilter> loginFilterRegistrationBean(
+      @Qualifier("TestLoginAuthenticationFilter") AuthenticationFilter authenticationFilter) {
+    FilterRegistrationBean<AuthenticationFilter> registrationBean =
+        new FilterRegistrationBean<>(authenticationFilter);
+    registrationBean.setEnabled(false); // 서블릿 필터에서 제거
+    return registrationBean;
+  }
 
-    @Bean
-    public FilterRegistrationBean<UnknownEndPointFilter> unknownFilterRegistrationBean(
-            UnknownEndPointFilter unknownEndPointFilter) {
-        FilterRegistrationBean<UnknownEndPointFilter> registrationBean =
-                new FilterRegistrationBean<>(unknownEndPointFilter);
-        registrationBean.setEnabled(false); // 서블릿 필터에서 제거
-        return registrationBean;
-    }
-
+  @Bean
+  public FilterRegistrationBean<UnknownEndPointFilter> unknownFilterRegistrationBean(
+      UnknownEndPointFilter unknownEndPointFilter) {
+    FilterRegistrationBean<UnknownEndPointFilter> registrationBean =
+        new FilterRegistrationBean<>(unknownEndPointFilter);
+    registrationBean.setEnabled(false); // 서블릿 필터에서 제거
+    return registrationBean;
+  }
 }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestJwtAuthenticationFilter.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestJwtAuthenticationFilter.java
@@ -1,14 +1,15 @@
 package com.fisa.bank.common.config.security.mock;
 
-import com.fisa.bank.common.config.security.resource.JwtAuthentication;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Objects;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -16,56 +17,53 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.security.web.authentication.AuthenticationFilter;
 
+import com.fisa.bank.common.config.security.resource.JwtAuthentication;
+
 /**
- * 테스트 환경에서 사용되는 Jwt 필터
- * Authorization 헤더에 jwt 토큰을 담아서 보내면, Authentication 으로 만들고
- * jwt 토큰이 없어도, Authentication 으로 만든다.
+ * 테스트 환경에서 사용되는 Jwt 필터 Authorization 헤더에 jwt 토큰을 담아서 보내면, Authentication 으로 만들고 jwt 토큰이 없어도,
+ * Authentication 으로 만든다.
  */
 @Slf4j
 public class TestJwtAuthenticationFilter extends AuthenticationFilter {
 
-    private final AuthenticationManager authenticationManager;
-    private final AuthenticationConverter authenticationConverter;
+  private final AuthenticationManager authenticationManager;
+  private final AuthenticationConverter authenticationConverter;
 
-    public TestJwtAuthenticationFilter(
-            AuthenticationManager authenticationManager,
-            AuthenticationConverter authenticationConverter) {
-        super(authenticationManager, authenticationConverter);
-        this.authenticationManager = authenticationManager;
-        this.authenticationConverter = authenticationConverter;
-    }
+  public TestJwtAuthenticationFilter(
+      AuthenticationManager authenticationManager,
+      AuthenticationConverter authenticationConverter) {
+    super(authenticationManager, authenticationConverter);
+    this.authenticationManager = authenticationManager;
+    this.authenticationConverter = authenticationConverter;
+  }
 
-    @Override
-    protected void doFilterInternal(
-            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
-        if (super.getRequestMatcher().matches(request)) {
-            // Authentication 변환
-            Authentication authentication = authenticationConverter.convert(request);
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    if (super.getRequestMatcher().matches(request)) {
+      // Authentication 변환
+      Authentication authentication = authenticationConverter.convert(request);
 
-            if (Objects.nonNull(authentication)) {
-                try {
-                    // 인증 진행
-                    authentication = authenticationManager.authenticate(authentication);
-                    // 컨텍스트 저장
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
-                } catch (AuthenticationException e) {
-                    log.warn("인증 예외 발생 : {}", e.getMessage());
-                    SecurityContextHolder.clearContext();
-                } catch (Exception e) {
-                    log.warn("예상하지 못한 예외 발생 : {}", e.getMessage());
-                    SecurityContextHolder.clearContext();
-                }
-            }
-
-            else{
-                // 빈 Authentication 객체 세팅
-                authentication = new JwtAuthentication(null, Collections.emptyList());
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            }
+      if (Objects.nonNull(authentication)) {
+        try {
+          // 인증 진행
+          authentication = authenticationManager.authenticate(authentication);
+          // 컨텍스트 저장
+          SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (AuthenticationException e) {
+          log.warn("인증 예외 발생 : {}", e.getMessage());
+          SecurityContextHolder.clearContext();
+        } catch (Exception e) {
+          log.warn("예상하지 못한 예외 발생 : {}", e.getMessage());
+          SecurityContextHolder.clearContext();
         }
-        filterChain.doFilter(request, response);
+      } else {
+        // 빈 Authentication 객체 세팅
+        authentication = new JwtAuthentication(null, Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+      }
     }
+    filterChain.doFilter(request, response);
+  }
 }
-
-

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestJwtAuthenticationFilter.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestJwtAuthenticationFilter.java
@@ -1,0 +1,71 @@
+package com.fisa.bank.common.config.security.mock;
+
+import com.fisa.bank.common.config.security.resource.JwtAuthentication;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.security.web.authentication.AuthenticationFilter;
+
+/**
+ * 테스트 환경에서 사용되는 Jwt 필터
+ * Authorization 헤더에 jwt 토큰을 담아서 보내면, Authentication 으로 만들고
+ * jwt 토큰이 없어도, Authentication 으로 만든다.
+ */
+@Slf4j
+public class TestJwtAuthenticationFilter extends AuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final AuthenticationConverter authenticationConverter;
+
+    public TestJwtAuthenticationFilter(
+            AuthenticationManager authenticationManager,
+            AuthenticationConverter authenticationConverter) {
+        super(authenticationManager, authenticationConverter);
+        this.authenticationManager = authenticationManager;
+        this.authenticationConverter = authenticationConverter;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        if (super.getRequestMatcher().matches(request)) {
+            // Authentication 변환
+            Authentication authentication = authenticationConverter.convert(request);
+
+            if (Objects.nonNull(authentication)) {
+                try {
+                    // 인증 진행
+                    authentication = authenticationManager.authenticate(authentication);
+                    // 컨텍스트 저장
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                } catch (AuthenticationException e) {
+                    log.warn("인증 예외 발생 : {}", e.getMessage());
+                    SecurityContextHolder.clearContext();
+                } catch (Exception e) {
+                    log.warn("예상하지 못한 예외 발생 : {}", e.getMessage());
+                    SecurityContextHolder.clearContext();
+                }
+            }
+
+            else{
+                // 빈 Authentication 객체 세팅
+                authentication = new JwtAuthentication(null, Collections.emptyList());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}
+
+

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestLoginAuthenticationFilter.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestLoginAuthenticationFilter.java
@@ -4,7 +4,9 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
+
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
@@ -12,9 +14,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.security.web.authentication.AuthenticationFilter;
 
-/**
- * 테스트 환경에서 임시 토큰을 발급하기 위한 LoginAuthenticationFilter
- */
+/** 테스트 환경에서 임시 토큰을 발급하기 위한 LoginAuthenticationFilter */
 public class TestLoginAuthenticationFilter extends AuthenticationFilter {
 
   private final AuthenticationManager authenticationManager;

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestLoginAuthenticationFilter.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestLoginAuthenticationFilter.java
@@ -1,0 +1,53 @@
+package com.fisa.bank.common.config.security.mock;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.security.web.authentication.AuthenticationFilter;
+
+/**
+ * 테스트 환경에서 임시 토큰을 발급하기 위한 LoginAuthenticationFilter
+ */
+public class TestLoginAuthenticationFilter extends AuthenticationFilter {
+
+  private final AuthenticationManager authenticationManager;
+  private final AuthenticationConverter authenticationConverter;
+
+  public TestLoginAuthenticationFilter(
+      AuthenticationManager authenticationManager,
+      AuthenticationConverter authenticationConverter) {
+    super(authenticationManager, authenticationConverter);
+    this.authenticationManager = authenticationManager;
+    this.authenticationConverter = authenticationConverter;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    if (super.getRequestMatcher().matches(request)) {
+      // Authentication 변환
+      Authentication authentication = authenticationConverter.convert(request);
+      // 인증 진행
+      try {
+        authentication = authenticationManager.authenticate(authentication);
+
+        if (authentication.isAuthenticated()) {
+          super.getSuccessHandler().onAuthenticationSuccess(request, response, authentication);
+        } else throw new AuthenticationServiceException("발생하면 안되는 예외");
+      } catch (AuthenticationException e) {
+        super.getFailureHandler().onAuthenticationFailure(request, response, e);
+      }
+
+      return; // 더이상 진행 X
+    }
+    filterChain.doFilter(request, response);
+  }
+}

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestLoginSuccessHandler.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestLoginSuccessHandler.java
@@ -3,28 +3,28 @@ package com.fisa.bank.common.config.security.mock;
 import static com.fisa.bank.common.config.security.jwt.JwtConst.ACCESS_TOKEN;
 import static com.fisa.bank.common.config.security.jwt.JwtConst.REFRESH_TOKEN;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fisa.bank.common.config.security.jwt.UserJwtGenerator;
-import com.fisa.bank.user.persistence.repository.UserAuthRepository;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fisa.bank.common.config.security.jwt.UserJwtGenerator;
 
 /** 로그인 성공 핸들러 스프링 시큐리티에 의해, 사용자 인증이 성공하면 Authentication 객체를 Jwt 토큰으로 인코딩하여 ResponseBody에 담는다. */
 @Slf4j
@@ -74,5 +74,4 @@ public class TestLoginSuccessHandler implements AuthenticationSuccessHandler {
       throw new IllegalStateException("Exception occur in json processing");
     }
   }
-
 }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestLoginSuccessHandler.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestLoginSuccessHandler.java
@@ -1,0 +1,78 @@
+package com.fisa.bank.common.config.security.mock;
+
+import static com.fisa.bank.common.config.security.jwt.JwtConst.ACCESS_TOKEN;
+import static com.fisa.bank.common.config.security.jwt.JwtConst.REFRESH_TOKEN;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fisa.bank.common.config.security.jwt.UserJwtGenerator;
+import com.fisa.bank.user.persistence.repository.UserAuthRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+/** 로그인 성공 핸들러 스프링 시큐리티에 의해, 사용자 인증이 성공하면 Authentication 객체를 Jwt 토큰으로 인코딩하여 ResponseBody에 담는다. */
+@Slf4j
+@RequiredArgsConstructor
+public class TestLoginSuccessHandler implements AuthenticationSuccessHandler {
+
+  private final UserJwtGenerator jwtGenerator;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void onAuthenticationSuccess(
+      HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+      throws IOException, ServletException {
+
+    if (authentication instanceof UsernamePasswordAuthenticationToken) {
+      User user = (User) authentication.getPrincipal();
+
+      if (Objects.nonNull(user)) {
+
+        Long userId = Long.valueOf(user.getUsername());
+
+        Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
+        String accessToken = jwtGenerator.createAccessToken(userId, authorities).getTokenValue();
+        String refreshToken = jwtGenerator.createRefreshToken(userId).getTokenValue();
+
+        response.setStatus(HttpStatus.OK.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(createBody(accessToken, refreshToken));
+        response.flushBuffer();
+        return;
+      }
+      log.warn("UserDetails : {}", user);
+      throw new IllegalStateException("UserDetails should be not null");
+    }
+
+    // UserIdAuthentication 이 아니면 예외
+    log.warn("Authentication : {}", authentication);
+    throw new IllegalStateException("Authentication is not UsernamePasswordAuthentication");
+  }
+
+  // AccessToken, RefreshToken 이 담긴 바디를 만드는 과정
+  private String createBody(String accessToken, String refreshToken) {
+    try {
+      return objectMapper.writeValueAsString(
+          Map.of(ACCESS_TOKEN, accessToken, REFRESH_TOKEN, refreshToken));
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("Exception occur in json processing");
+    }
+  }
+
+}

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestUserDetailsService.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestUserDetailsService.java
@@ -1,15 +1,14 @@
 package com.fisa.bank.common.config.security.mock;
 
 import java.util.Collections;
+
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
-/**
- * 테스트용 UserDetailsService
- */
+/** 테스트용 UserDetailsService */
 @Component
 public class TestUserDetailsService implements UserDetailsService {
 
@@ -17,5 +16,4 @@ public class TestUserDetailsService implements UserDetailsService {
   public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
     return new User(userId, "{noop}password", Collections.emptyList());
   }
-
 }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestUserDetailsService.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestUserDetailsService.java
@@ -1,0 +1,21 @@
+package com.fisa.bank.common.config.security.mock;
+
+import java.util.Collections;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+/**
+ * 테스트용 UserDetailsService
+ */
+@Component
+public class TestUserDetailsService implements UserDetailsService {
+
+  @Override
+  public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+    return new User(userId, "{noop}password", Collections.emptyList());
+  }
+
+}

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestUsernamePasswordAuthenticationConverter.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestUsernamePasswordAuthenticationConverter.java
@@ -1,6 +1,7 @@
 package com.fisa.bank.common.config.security.mock;
 
 import jakarta.servlet.http.HttpServletRequest;
+
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -13,12 +14,13 @@ public class TestUsernamePasswordAuthenticationConverter implements Authenticati
 
   @Override
   public Authentication convert(HttpServletRequest request) {
-      try{
-          String userId = request.getRequestURI().replace("/api/login/", "");
+    try {
+      String userId = request.getRequestURI().replace("/api/login/", "");
 
-          return new UsernamePasswordAuthenticationToken(userId, "{noop}password");
+      return new UsernamePasswordAuthenticationToken(userId, "{noop}password");
     } catch (Exception e) {
-        throw new AuthenticationServiceException("Failed to create UsernamePasswordAuthentication", e);
+      throw new AuthenticationServiceException(
+          "Failed to create UsernamePasswordAuthentication", e);
     }
   }
 }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestUsernamePasswordAuthenticationConverter.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestUsernamePasswordAuthenticationConverter.java
@@ -1,0 +1,24 @@
+package com.fisa.bank.common.config.security.mock;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationConverter;
+import org.springframework.stereotype.Component;
+
+/** 사용자가 요청한 HTTP Request에서 자격 증명(ID/PW)을 꺼내서 Authentication으로 만드는 역할 */
+@Component("TestUsernamePasswordConverter")
+public class TestUsernamePasswordAuthenticationConverter implements AuthenticationConverter {
+
+  @Override
+  public Authentication convert(HttpServletRequest request) {
+      try{
+          String userId = request.getRequestURI().replace("/api/login/", "");
+
+          return new UsernamePasswordAuthenticationToken(userId, "{noop}password");
+    } catch (Exception e) {
+        throw new AuthenticationServiceException("Failed to create UsernamePasswordAuthentication", e);
+    }
+  }
+}

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestUsernamePasswordAuthenticationProvider.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestUsernamePasswordAuthenticationProvider.java
@@ -1,0 +1,26 @@
+package com.fisa.bank.common.config.security.mock;
+
+import java.util.Collection;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+public class TestUsernamePasswordAuthenticationProvider implements AuthenticationProvider {
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String userId = (String) authentication.getPrincipal();
+        String password = (String) authentication.getCredentials();
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+
+        return new UsernamePasswordAuthenticationToken(new User(userId, password, authorities), password, authorities);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+}

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestUsernamePasswordAuthenticationProvider.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestUsernamePasswordAuthenticationProvider.java
@@ -1,6 +1,7 @@
 package com.fisa.bank.common.config.security.mock;
 
 import java.util.Collection;
+
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -10,17 +11,18 @@ import org.springframework.security.core.userdetails.User;
 
 public class TestUsernamePasswordAuthenticationProvider implements AuthenticationProvider {
 
-    @Override
-    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
-        String userId = (String) authentication.getPrincipal();
-        String password = (String) authentication.getCredentials();
-        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+  @Override
+  public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    String userId = (String) authentication.getPrincipal();
+    String password = (String) authentication.getCredentials();
+    Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
 
-        return new UsernamePasswordAuthenticationToken(new User(userId, password, authorities), password, authorities);
-    }
+    return new UsernamePasswordAuthenticationToken(
+        new User(userId, password, authorities), password, authorities);
+  }
 
-    @Override
-    public boolean supports(Class<?> authentication) {
-        return authentication.equals(UsernamePasswordAuthenticationToken.class);
-    }
+  @Override
+  public boolean supports(Class<?> authentication) {
+    return authentication.equals(UsernamePasswordAuthenticationToken.class);
+  }
 }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -19,6 +20,7 @@ import org.springframework.security.web.servlet.util.matcher.PathPatternRequestM
 import org.springframework.security.web.util.matcher.RequestMatcher;
 
 // OAuth2.0 Authorization Server 를 설정하는 Config
+@Profile({"local", "dev", "prod"})
 @Configuration
 public class AuthorizationConfig {
 

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
@@ -45,7 +45,8 @@ public class AuthorizationConfig {
   public AuthenticationFilter unAuthenticated(
       @Qualifier("LoginSuccessHandler") AuthenticationSuccessHandler successHandler,
       @Qualifier("LoginFailureHandler") AuthenticationFailureHandler failureHandler,
-      @Qualifier("UsernamePasswordAuthenticationConverter") AuthenticationConverter appUnAuthConverter,
+      @Qualifier("UsernamePasswordAuthenticationConverter")
+          AuthenticationConverter appUnAuthConverter,
       @Qualifier("UsernamePasswordAuthenticationProvider")
           AuthenticationProvider authenticationProvider) {
     AuthenticationManager authenticationManager = new ProviderManager(authenticationProvider);
@@ -118,8 +119,8 @@ public class AuthorizationConfig {
   }
 
   @Bean("UsernamePasswordAuthenticationConverter")
-  public AuthenticationConverter usernamePasswordAuthenticationConverter(ObjectMapper om){
-      return new UsernamePasswordAuthenticationConverter(om);
+  public AuthenticationConverter usernamePasswordAuthenticationConverter(ObjectMapper om) {
+    return new UsernamePasswordAuthenticationConverter(om);
   }
 
   @Bean("UsernamePasswordAuthenticationProvider")

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
@@ -1,8 +1,5 @@
 package com.fisa.bank.common.config.security.resource;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fisa.bank.common.config.security.jwt.UserJwtGenerator;
-import com.fisa.bank.user.persistence.repository.UserAuthRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -23,6 +20,10 @@ import org.springframework.security.web.authentication.AuthenticationFilter;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fisa.bank.common.config.security.jwt.UserJwtGenerator;
+import com.fisa.bank.user.persistence.repository.UserAuthRepository;
 
 // OAuth2.0 Authorization Server 를 설정하는 Config
 @Profile({"local", "dev", "prod"})
@@ -45,8 +46,9 @@ public class AuthorizationConfig {
       @Qualifier("LoginSuccessHandler") AuthenticationSuccessHandler successHandler,
       @Qualifier("LoginFailureHandler") AuthenticationFailureHandler failureHandler,
       @Qualifier("AppUnAuthenticationConverter") AuthenticationConverter appUnAuthConverter,
-      @Qualifier("UsernamePasswordAuthenticationProvider") AuthenticationProvider authenticationProvider) {
-      AuthenticationManager authenticationManager = new ProviderManager(authenticationProvider);
+      @Qualifier("UsernamePasswordAuthenticationProvider")
+          AuthenticationProvider authenticationProvider) {
+    AuthenticationManager authenticationManager = new ProviderManager(authenticationProvider);
     AuthenticationFilter authenticationFilter =
         new LoginAuthenticationFilter(authenticationManager, appUnAuthConverter);
     RequestMatcher requestMatcher =
@@ -88,45 +90,43 @@ public class AuthorizationConfig {
   }
 
   @Bean("UserDetailsService")
-  public UserDetailsService userDetailsService(UserAuthRepository userAuthRepository){
-      return new CustomUserDetailsService(userAuthRepository);
+  public UserDetailsService userDetailsService(UserAuthRepository userAuthRepository) {
+    return new CustomUserDetailsService(userAuthRepository);
   }
 
-    @Bean("BcryptPasswordEncoder")
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
+  @Bean("BcryptPasswordEncoder")
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
+  }
 
   @Bean("JwtAuthenticationConverter")
-  public AuthenticationConverter authenticationConverter(){
-      return new JwtAuthenticationConverter();
+  public AuthenticationConverter authenticationConverter() {
+    return new JwtAuthenticationConverter();
   }
 
   @Bean("LoginFailureHandler")
-    public AuthenticationFailureHandler loginFailureHandler(ObjectMapper om){
-      return new LoginFailureHandler(om);
+  public AuthenticationFailureHandler loginFailureHandler(ObjectMapper om) {
+    return new LoginFailureHandler(om);
   }
 
   @Bean("LoginSuccessHandler")
   public AuthenticationSuccessHandler loginSuccessHandler(
-          ObjectMapper objectMapper,
-          UserAuthRepository userAuthRepository,
-          UserJwtGenerator jwtGenerator
-  ){
-      return new LoginSuccessHandler(jwtGenerator, objectMapper, userAuthRepository);
+      ObjectMapper objectMapper,
+      UserAuthRepository userAuthRepository,
+      UserJwtGenerator jwtGenerator) {
+    return new LoginSuccessHandler(jwtGenerator, objectMapper, userAuthRepository);
   }
 
   @Bean("UsernamePasswordAuthenticationProvider")
   public AuthenticationProvider usernamePasswordAuthenticationProvider(
-          @Qualifier("BcryptPasswordEncoder") PasswordEncoder passwordEncoder,
-          @Qualifier("UserDetailsService") UserDetailsService userDetailsService
-  ){
-      return new UsernamePasswordAuthenticationProvider(passwordEncoder, userDetailsService);
+      @Qualifier("BcryptPasswordEncoder") PasswordEncoder passwordEncoder,
+      @Qualifier("UserDetailsService") UserDetailsService userDetailsService) {
+    return new UsernamePasswordAuthenticationProvider(passwordEncoder, userDetailsService);
   }
 
   @Bean("JwtAuthenticationProvider")
-  public AuthenticationProvider jwtAuthenticationProvider(JwtDecoder jwtDecoder){
-      return new JwtAuthenticationProvider(jwtDecoder);
+  public AuthenticationProvider jwtAuthenticationProvider(JwtDecoder jwtDecoder) {
+    return new JwtAuthenticationProvider(jwtDecoder);
   }
 
   /** 로그인 전용 필터 서블릿 필터에서 제외 */

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
@@ -1,5 +1,8 @@
 package com.fisa.bank.common.config.security.resource;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fisa.bank.common.config.security.jwt.UserJwtGenerator;
+import com.fisa.bank.user.persistence.repository.UserAuthRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -38,8 +41,8 @@ public class AuthorizationConfig {
   @Bean("unAuthenticatedFilter")
   public AuthenticationFilter unAuthenticated(
       AuthenticationManager authenticationManager,
-      AuthenticationSuccessHandler successHandler,
-      AuthenticationFailureHandler failureHandler,
+      @Qualifier("LoginSuccessHandler") AuthenticationSuccessHandler successHandler,
+      @Qualifier("LoginFailureHandler") AuthenticationFailureHandler failureHandler,
       @Qualifier("AppUnAuthenticationConverter") AuthenticationConverter appUnAuthConverter) {
     AuthenticationFilter authenticationFilter =
         new LoginAuthenticationFilter(authenticationManager, appUnAuthConverter);
@@ -71,11 +74,6 @@ public class AuthorizationConfig {
     return authenticationFilter;
   }
 
-  @Bean
-  public PasswordEncoder passwordEncoder() {
-    return new BCryptPasswordEncoder();
-  }
-
   /** jwt 인증필터 서블릿 필터에서 제외 */
   @Bean
   public FilterRegistrationBean<AuthenticationFilter> jwtFilterRegistrationBean(
@@ -86,9 +84,28 @@ public class AuthorizationConfig {
     return registrationBean;
   }
 
+    @Bean("BcryptPasswordEncoder")
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
   @Bean("AppAuthenticationConverter")
   public AuthenticationConverter authenticationConverter(){
       return new JwtAuthenticationConverter();
+  }
+
+  @Bean("LoginFailureHandler")
+    public AuthenticationFailureHandler loginFailureHandler(ObjectMapper om){
+      return new LoginFailureHandler(om);
+  }
+
+  @Bean("LoginSuccessHandler")
+  public AuthenticationSuccessHandler loginSuccessHandler(
+          ObjectMapper objectMapper,
+          UserAuthRepository userAuthRepository,
+          UserJwtGenerator jwtGenerator
+  ){
+      return new LoginSuccessHandler(jwtGenerator, objectMapper, userAuthRepository);
   }
 
   /** 로그인 전용 필터 서블릿 필터에서 제외 */

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
@@ -42,10 +42,11 @@ public class AuthorizationConfig {
    */
   @Bean("unAuthenticatedFilter")
   public AuthenticationFilter unAuthenticated(
-      AuthenticationManager authenticationManager,
       @Qualifier("LoginSuccessHandler") AuthenticationSuccessHandler successHandler,
       @Qualifier("LoginFailureHandler") AuthenticationFailureHandler failureHandler,
-      @Qualifier("AppUnAuthenticationConverter") AuthenticationConverter appUnAuthConverter) {
+      @Qualifier("AppUnAuthenticationConverter") AuthenticationConverter appUnAuthConverter,
+      @Qualifier("UsernamePasswordAuthenticationProvider") AuthenticationProvider authenticationProvider) {
+      AuthenticationManager authenticationManager = new ProviderManager(authenticationProvider);
     AuthenticationFilter authenticationFilter =
         new LoginAuthenticationFilter(authenticationManager, appUnAuthConverter);
     RequestMatcher requestMatcher =
@@ -115,8 +116,16 @@ public class AuthorizationConfig {
       return new LoginSuccessHandler(jwtGenerator, objectMapper, userAuthRepository);
   }
 
+  @Bean("UsernamePasswordAuthenticationProvider")
+  public AuthenticationProvider usernamePasswordAuthenticationProvider(
+          @Qualifier("BcryptPasswordEncoder") PasswordEncoder passwordEncoder,
+          @Qualifier("UserDetailsService") UserDetailsService userDetailsService
+  ){
+      return new UsernamePasswordAuthenticationProvider(passwordEncoder, userDetailsService);
+  }
+
   @Bean("JwtAuthenticationProvider")
-  public AuthenticationProvider authenticationProvider(JwtDecoder jwtDecoder){
+  public AuthenticationProvider jwtAuthenticationProvider(JwtDecoder jwtDecoder){
       return new JwtAuthenticationProvider(jwtDecoder);
   }
 

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
@@ -66,7 +66,7 @@ public class AuthorizationConfig {
   @Bean("authenticatedFilter")
   public AuthenticationFilter authenticated(
       @Qualifier("JwtAuthenticationProvider") AuthenticationProvider authenticationProvider,
-      @Qualifier("AppAuthenticationConverter") AuthenticationConverter authenticationConverter) {
+      @Qualifier("JwtAuthenticationConverter") AuthenticationConverter authenticationConverter) {
     AuthenticationManager authenticationManager = new ProviderManager(authenticationProvider);
     AuthenticationFilter authenticationFilter =
         new JwtAuthenticationFilter(authenticationManager, authenticationConverter);

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
@@ -45,7 +45,7 @@ public class AuthorizationConfig {
   public AuthenticationFilter unAuthenticated(
       @Qualifier("LoginSuccessHandler") AuthenticationSuccessHandler successHandler,
       @Qualifier("LoginFailureHandler") AuthenticationFailureHandler failureHandler,
-      @Qualifier("AppUnAuthenticationConverter") AuthenticationConverter appUnAuthConverter,
+      @Qualifier("UsernamePasswordAuthenticationConverter") AuthenticationConverter appUnAuthConverter,
       @Qualifier("UsernamePasswordAuthenticationProvider")
           AuthenticationProvider authenticationProvider) {
     AuthenticationManager authenticationManager = new ProviderManager(authenticationProvider);
@@ -115,6 +115,11 @@ public class AuthorizationConfig {
       UserAuthRepository userAuthRepository,
       UserJwtGenerator jwtGenerator) {
     return new LoginSuccessHandler(jwtGenerator, objectMapper, userAuthRepository);
+  }
+
+  @Bean("UsernamePasswordAuthenticationConverter")
+  public AuthenticationConverter usernamePasswordAuthenticationConverter(ObjectMapper om){
+      return new UsernamePasswordAuthenticationConverter(om);
   }
 
   @Bean("UsernamePasswordAuthenticationProvider")

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.authentication.AuthenticationFilter;
@@ -64,7 +65,7 @@ public class AuthorizationConfig {
    */
   @Bean("authenticatedFilter")
   public AuthenticationFilter authenticated(
-      @Qualifier("AppAuthenticationProvider") AuthenticationProvider authenticationProvider,
+      @Qualifier("JwtAuthenticationProvider") AuthenticationProvider authenticationProvider,
       @Qualifier("AppAuthenticationConverter") AuthenticationConverter authenticationConverter) {
     AuthenticationManager authenticationManager = new ProviderManager(authenticationProvider);
     AuthenticationFilter authenticationFilter =
@@ -95,7 +96,7 @@ public class AuthorizationConfig {
         return new BCryptPasswordEncoder();
     }
 
-  @Bean("AppAuthenticationConverter")
+  @Bean("JwtAuthenticationConverter")
   public AuthenticationConverter authenticationConverter(){
       return new JwtAuthenticationConverter();
   }
@@ -112,6 +113,11 @@ public class AuthorizationConfig {
           UserJwtGenerator jwtGenerator
   ){
       return new LoginSuccessHandler(jwtGenerator, objectMapper, userAuthRepository);
+  }
+
+  @Bean("JwtAuthenticationProvider")
+  public AuthenticationProvider authenticationProvider(JwtDecoder jwtDecoder){
+      return new JwtAuthenticationProvider(jwtDecoder);
   }
 
   /** 로그인 전용 필터 서블릿 필터에서 제외 */

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.authentication.AuthenticationConverter;
@@ -82,6 +83,11 @@ public class AuthorizationConfig {
         new FilterRegistrationBean<>(authenticationFilter);
     registrationBean.setEnabled(false); // 서블릿 필터에서 제거
     return registrationBean;
+  }
+
+  @Bean("UserDetailsService")
+  public UserDetailsService userDetailsService(UserAuthRepository userAuthRepository){
+      return new CustomUserDetailsService(userAuthRepository);
   }
 
     @Bean("BcryptPasswordEncoder")

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/AuthorizationConfig.java
@@ -86,6 +86,11 @@ public class AuthorizationConfig {
     return registrationBean;
   }
 
+  @Bean("AppAuthenticationConverter")
+  public AuthenticationConverter authenticationConverter(){
+      return new JwtAuthenticationConverter();
+  }
+
   /** 로그인 전용 필터 서블릿 필터에서 제외 */
   @Bean
   public FilterRegistrationBean<AuthenticationFilter> loginFilterRegistrationBean(

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/CustomUserDetailsService.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/CustomUserDetailsService.java
@@ -8,7 +8,6 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.stereotype.Component;
 
 import com.fisa.bank.user.persistence.entity.UserAuth;
 import com.fisa.bank.user.persistence.repository.UserAuthRepository;

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/CustomUserDetailsService.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/CustomUserDetailsService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 import com.fisa.bank.user.persistence.entity.UserAuth;
 import com.fisa.bank.user.persistence.repository.UserAuthRepository;
 
-@Component
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationConverter.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationConverter.java
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationConverter;
-import org.springframework.stereotype.Component;
 
 /** 클라이언트가 보낸 Jwt 토큰을 Authentication 으로 변환해주는 역할 */
 public class JwtAuthenticationConverter implements AuthenticationConverter {

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationConverter.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationConverter.java
@@ -8,7 +8,6 @@ import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.stereotype.Component;
 
 /** 클라이언트가 보낸 Jwt 토큰을 Authentication 으로 변환해주는 역할 */
-@Component("AppAuthenticationConverter")
 public class JwtAuthenticationConverter implements AuthenticationConverter {
 
   @Override

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationProvider.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationProvider.java
@@ -50,6 +50,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
     } catch (JwtEncodingException e) {
       throw new InvalidBearerTokenException("Jwt format is invalid", e);
     } catch (Exception e) {
+        e.printStackTrace();
       throw new AuthenticationServiceException("Unexpected Exception occurred", e);
     }
   }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationProvider.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationProvider.java
@@ -23,7 +23,6 @@ import org.springframework.security.oauth2.server.resource.InvalidBearerTokenExc
 import org.springframework.stereotype.Component;
 
 /** UserIdAuthentication의 인증을 수행하는 Provider */
-@Component("AppAuthenticationProvider")
 public class JwtAuthenticationProvider implements AuthenticationProvider {
 
   private final JwtDecoder jwtDecoder;

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationProvider.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationProvider.java
@@ -2,11 +2,12 @@ package com.fisa.bank.common.config.security.resource;
 
 import static com.fisa.bank.common.config.security.jwt.JwtConst.*;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AccountExpiredException;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.AuthenticationServiceException;

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationProvider.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationProvider.java
@@ -50,7 +50,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
     } catch (JwtEncodingException e) {
       throw new InvalidBearerTokenException("Jwt format is invalid", e);
     } catch (Exception e) {
-        e.printStackTrace();
+      e.printStackTrace();
       throw new AuthenticationServiceException("Unexpected Exception occurred", e);
     }
   }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationProvider.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationProvider.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AccountExpiredException;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.AuthenticationServiceException;
@@ -22,6 +23,7 @@ import org.springframework.security.oauth2.jwt.JwtValidationException;
 import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
 
 /** UserIdAuthentication의 인증을 수행하는 Provider */
+@Slf4j
 public class JwtAuthenticationProvider implements AuthenticationProvider {
 
   private final JwtDecoder jwtDecoder;
@@ -50,7 +52,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
     } catch (JwtEncodingException e) {
       throw new InvalidBearerTokenException("Jwt format is invalid", e);
     } catch (Exception e) {
-      e.printStackTrace();
+      log.error("Unexpected Exception occurred", e);
       throw new AuthenticationServiceException("Unexpected Exception occurred", e);
     }
   }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationProvider.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/JwtAuthenticationProvider.java
@@ -20,7 +20,6 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncodingException;
 import org.springframework.security.oauth2.jwt.JwtValidationException;
 import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
-import org.springframework.stereotype.Component;
 
 /** UserIdAuthentication의 인증을 수행하는 Provider */
 public class JwtAuthenticationProvider implements AuthenticationProvider {

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/LoginFailureHandler.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/LoginFailureHandler.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
-import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/LoginFailureHandler.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/LoginFailureHandler.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /** 로그인 실패 시 핸들러 401 unAuthorized 응답과 합께 에러 응답을 바디로 담아서 보낸다. */
-@Component
 @RequiredArgsConstructor
 public class LoginFailureHandler implements AuthenticationFailureHandler {
 

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/LoginSuccessHandler.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/LoginSuccessHandler.java
@@ -30,9 +30,9 @@ import com.fisa.bank.common.config.security.jwt.UserJwtGenerator;
 import com.fisa.bank.user.persistence.repository.UserAuthRepository;
 
 /** 로그인 성공 핸들러 스프링 시큐리티에 의해, 사용자 인증이 성공하면 Authentication 객체를 Jwt 토큰으로 인코딩하여 ResponseBody에 담는다. */
-@Component
-@RequiredArgsConstructor
+
 @Slf4j
+@RequiredArgsConstructor
 public class LoginSuccessHandler implements AuthenticationSuccessHandler {
 
   private final UserJwtGenerator jwtGenerator;

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/LoginSuccessHandler.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/LoginSuccessHandler.java
@@ -22,7 +22,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,7 +29,6 @@ import com.fisa.bank.common.config.security.jwt.UserJwtGenerator;
 import com.fisa.bank.user.persistence.repository.UserAuthRepository;
 
 /** 로그인 성공 핸들러 스프링 시큐리티에 의해, 사용자 인증이 성공하면 Authentication 객체를 Jwt 토큰으로 인코딩하여 ResponseBody에 담는다. */
-
 @Slf4j
 @RequiredArgsConstructor
 public class LoginSuccessHandler implements AuthenticationSuccessHandler {

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/UsernamePasswordAuthenticationConverter.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/UsernamePasswordAuthenticationConverter.java
@@ -10,7 +10,6 @@ import org.springframework.security.authentication.AuthenticationServiceExceptio
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationConverter;
-import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/UsernamePasswordAuthenticationConverter.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/UsernamePasswordAuthenticationConverter.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /** 사용자가 요청한 HTTP Request에서 자격 증명(ID/PW)을 꺼내서 Authentication으로 만드는 역할 */
-@Component("AppUnAuthenticationConverter")
 @RequiredArgsConstructor
 public class UsernamePasswordAuthenticationConverter implements AuthenticationConverter {
 

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/UsernamePasswordAuthenticationProvider.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/UsernamePasswordAuthenticationProvider.java
@@ -10,7 +10,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 public class UsernamePasswordAuthenticationProvider implements AuthenticationProvider {

--- a/bank/src/main/java/com/fisa/bank/common/config/security/resource/UsernamePasswordAuthenticationProvider.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/resource/UsernamePasswordAuthenticationProvider.java
@@ -12,7 +12,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
-@Component("UsernamePassword")
 @RequiredArgsConstructor
 public class UsernamePasswordAuthenticationProvider implements AuthenticationProvider {
 

--- a/bank/src/main/resources/application.yml
+++ b/bank/src/main/resources/application.yml
@@ -6,6 +6,7 @@ spring:
     include:
       - db
       - auth
+    active: ${PROFILE}
 
 bank:
   code: "020"  # 우리 은행 코드


### PR DESCRIPTION
closes #67 

## 테스트 환경 시큐리티 필터체인 설정
테스트 환경에서 간편하게 테스트를 수행할 수 있도록 시큐리티 필터체인 설정을 추가하였습니다.

`TestSecurityFilterChainConfig` 와 `SecurityFilterChainConfig` 로 환경별 동작하는 필터체인을 분리하였습니다.

- `TestSecurityFilterChainConfig` : 테스트 환경에서 동작하는 필터체인 (profile : test)
- `SecurityFilterChainConfig` : 로컬, 운영, 개발 환경에서 동작하는 필터체인 (profile : local, dev, prod)

또한 각각의 `profile` 환경마다 사용되는 빈, 컴포넌트가 다르므로 환경 별 컴포넌트를 다르게 사용하기 위해 빈 등록 과정은 `@Component`가 아닌 `AuthorizationConfig` 와 `TestAuthorizationConfig` 에서 수행합니다.

- `AuthorizationConfig` : 로컬, 운영, 개발 환경에서  등록할 시큐리티 관련 빈 설정 클래스
- `TestAuthorizationConfig` : 테스트 환경에서 등록할 시큐리티 관련 빈 설정 클래스

## 사용법
- 사용자 토큰 발급 : `/api/login/{userId}` 해당 userId 가 담긴 AccessToken 을 발급합니다. 응답 구조는 기존과 동일합니다.
- api 호출 : 기존과 동일하게 Authorization 헤더에 AccessToken 을 담아서 보내면 됩니다.
<img width="1620" height="580" alt="image" src="https://github.com/user-attachments/assets/07db6a85-9979-4c5c-911d-7552c2bc5c05" />
