### PR TITLE
[refactor] 소유권 검증 로직 분리 

### DIFF
--- a/bank/src/main/java/com/fisa/bank/account/application/service/AccountService.java
+++ b/bank/src/main/java/com/fisa/bank/account/application/service/AccountService.java
@@ -17,6 +17,8 @@ import com.fisa.bank.account.application.service.reader.AccountReader;
 import com.fisa.bank.account.application.util.AccountNumberGenerator;
 import com.fisa.bank.account.persistence.entity.Account;
 import com.fisa.bank.account.persistence.repository.AccountRepository;
+import com.fisa.bank.common.aop.annotation.DomainType;
+import com.fisa.bank.common.aop.annotation.VerifyOwner;
 import com.fisa.bank.user.persistence.entity.User;
 
 @Service
@@ -42,9 +44,10 @@ public class AccountService {
   }
 
   // 계좌 상세 조회
+  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")
   @Transactional(readOnly = true)
-  public AccountDetailResponse getAccountDetail(String accountNumber, Long userId) {
-    Account account = accountReader.getOwnedAccount(accountNumber, userId);
+  public AccountDetailResponse getAccountDetail(String accountNumber) {
+    Account account = accountReader.getAccountByAccountNumber(accountNumber);
     return AccountDetailResponse.from(account);
   }
 
@@ -52,14 +55,14 @@ public class AccountService {
   @Transactional(readOnly = true)
   public List<AccountListResponse> getAccountsByUserId(Long userId) {
     User user = accountReader.getUserById(userId);
-
     return accountRepository.findAllByUser(user).stream().map(AccountListResponse::from).toList();
   }
 
   // 계좌 삭제
+  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")
   @Transactional
-  public void deleteAccount(String accountNumber, Long userId) {
-    Account account = accountReader.getOwnedAccount(accountNumber, userId);
+  public void deleteAccount(String accountNumber) {
+    Account account = accountReader.getAccountByAccountNumber(accountNumber);
 
     // 잔액이 있는 경우 예외 처리
     if (account.getBalance().compareTo(BigDecimal.ZERO) != 0) {

--- a/bank/src/main/java/com/fisa/bank/account/application/service/AccountTransactionService.java
+++ b/bank/src/main/java/com/fisa/bank/account/application/service/AccountTransactionService.java
@@ -26,7 +26,6 @@ import com.fisa.bank.account.persistence.entity.Account;
 import com.fisa.bank.account.persistence.entity.AccountTransaction;
 import com.fisa.bank.account.persistence.entity.CardTransaction;
 import com.fisa.bank.account.persistence.enums.TransactionType;
-import com.fisa.bank.account.persistence.repository.AccountRepository;
 import com.fisa.bank.account.persistence.repository.AccountTransactionRepository;
 import com.fisa.bank.account.persistence.repository.CardTransactionRepository;
 import com.fisa.bank.common.aop.annotation.DomainType;
@@ -38,7 +37,6 @@ public class AccountTransactionService {
 
   private final AccountTransactionRepository accountTransactionRepository;
   private final CardTransactionRepository cardTransactionRepository;
-  private final AccountRepository accountRepository;
   private final AccountReader accountReader;
 
   @Value("${bank.code}")

--- a/bank/src/main/java/com/fisa/bank/account/application/service/AccountTransactionService.java
+++ b/bank/src/main/java/com/fisa/bank/account/application/service/AccountTransactionService.java
@@ -26,8 +26,11 @@ import com.fisa.bank.account.persistence.entity.Account;
 import com.fisa.bank.account.persistence.entity.AccountTransaction;
 import com.fisa.bank.account.persistence.entity.CardTransaction;
 import com.fisa.bank.account.persistence.enums.TransactionType;
+import com.fisa.bank.account.persistence.repository.AccountRepository;
 import com.fisa.bank.account.persistence.repository.AccountTransactionRepository;
 import com.fisa.bank.account.persistence.repository.CardTransactionRepository;
+import com.fisa.bank.common.aop.annotation.DomainType;
+import com.fisa.bank.common.aop.annotation.VerifyOwner;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +38,7 @@ public class AccountTransactionService {
 
   private final AccountTransactionRepository accountTransactionRepository;
   private final CardTransactionRepository cardTransactionRepository;
+  private final AccountRepository accountRepository;
   private final AccountReader accountReader;
 
   @Value("${bank.code}")
@@ -73,11 +77,10 @@ public class AccountTransactionService {
   }
 
   // 출금
+  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")
   @Transactional
-  public AccountTransactionResponse withdraw(
-      String accountNumber, AccountWithdrawRequest request, Long userId) {
-    // 토큰을 통해 현재 사용자가 소유한 계좌인지 검증
-    Account account = accountReader.getOwnedAccountWithLock(accountNumber, userId);
+  public AccountTransactionResponse withdraw(String accountNumber, AccountWithdrawRequest request) {
+    Account account = accountReader.getAccountByAccountNumberWithLock(accountNumber);
 
     AccountTransaction trx =
         recordTransaction(account, request.amount(), TransactionType.ATM_WITHDRAW, false, null);
@@ -86,11 +89,10 @@ public class AccountTransactionService {
   }
 
   // 입금
+  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")
   @Transactional
-  public AccountTransactionResponse deposit(
-      String accountNumber, AccountDepositRequest request, Long userId) {
-    // 토큰을 통해 현재 사용자가 소유한 계좌인지 검증
-    Account account = accountReader.getOwnedAccountWithLock(accountNumber, userId);
+  public AccountTransactionResponse deposit(String accountNumber, AccountDepositRequest request) {
+    Account account = accountReader.getAccountByAccountNumberWithLock(accountNumber);
 
     AccountTransaction trx =
         recordTransaction(account, request.amount(), TransactionType.ATM_DEPOSIT, true, null);
@@ -99,52 +101,39 @@ public class AccountTransactionService {
   }
 
   // 송금
+  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "fromAccountNumber")
   @Transactional
-  public TransferResponse transfer(TransferRequest request, Long userId) {
+  public TransferResponse transfer(TransferRequest request) {
     String fromNo = request.fromAccountNumber();
     String toNo = request.toAccountNumber();
     BigDecimal amount = request.amount();
 
-    // 자기 자신으로 송금 방지
     if (ourBankCode.equals(request.toBankCode()) && fromNo.equals(toNo)) {
       throw new InvalidTransferTargetException();
     }
 
     if (ourBankCode.equals(request.toBankCode())) {
-      // 같은 은행: 두 계좌 모두 조회 및 락 획득
-      AccountReader.TransferAccountsPair accounts =
-          accountReader.lockTransferAccounts(fromNo, toNo, userId);
+      var pair = accountReader.lockTransferAccounts(fromNo, toNo);
+      Account from = pair.from();
+      Account to = pair.to();
 
-      // 거래 처리
+      recordTransaction(from, amount, TransactionType.TRANSFER_SEND, false, to.getAccountNumber());
       recordTransaction(
-          accounts.from(),
-          amount,
-          TransactionType.TRANSFER_SEND,
-          false,
-          accounts.to().getAccountNumber());
-      recordTransaction(
-          accounts.to(),
-          amount,
-          TransactionType.TRANSFER_RECEIVE,
-          true,
-          accounts.from().getAccountNumber());
+          to, amount, TransactionType.TRANSFER_RECEIVE, true, from.getAccountNumber());
 
-      return TransferResponse.of(accounts.from(), accounts.to(), amount);
-
+      return TransferResponse.of(from, to, amount);
     } else {
-      // 타행: 보내는 쪽만 락
-      Account from = accountReader.getOwnedAccountWithLock(fromNo, userId);
+      Account from = accountReader.getAccountByAccountNumberWithLock(fromNo);
       recordTransaction(from, amount, TransactionType.EXTERNAL_TRANSFER_SEND, false, toNo);
       return TransferResponse.ofExternal(from, toNo, amount);
     }
   }
 
   // 카드 결제
+  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")
   @Transactional
-  public CardPaymentResponse payByCard(
-      String accountNumber, CardPaymentRequest request, Long userId) {
-    // 토큰을 통해 현재 사용자가 소유한 계좌인지 검증
-    Account account = accountReader.getOwnedAccountWithLock(accountNumber, userId);
+  public CardPaymentResponse payByCard(String accountNumber, CardPaymentRequest request) {
+    Account account = accountReader.getAccountByAccountNumberWithLock(accountNumber);
 
     // 계좌에도 로그 남기기위해 반영
     recordTransaction(
@@ -169,10 +158,10 @@ public class AccountTransactionService {
     return CardPaymentResponse.from(saved);
   }
 
+  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")
   public AccountTransactionListResponse getTransactions(
-      String accountNumber, LocalDate startDate, LocalDate endDate, Long userId) {
-    // 토큰을 통해 현재 사용자가 소유한 계좌인지 검증
-    Account account = accountReader.getOwnedAccount(accountNumber, userId);
+      String accountNumber, LocalDate startDate, LocalDate endDate) {
+    Account account = accountReader.getAccountByAccountNumber(accountNumber);
 
     // 거래내역 조회
     List<AccountTransactionResponse> transactions =

--- a/bank/src/main/java/com/fisa/bank/account/application/service/reader/AccountReader.java
+++ b/bank/src/main/java/com/fisa/bank/account/application/service/reader/AccountReader.java
@@ -6,20 +6,18 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
-import com.fisa.bank.account.application.exception.AccessDeniedException;
 import com.fisa.bank.account.application.exception.AccountNotFoundException;
 import com.fisa.bank.account.persistence.entity.Account;
 import com.fisa.bank.account.persistence.repository.AccountRepository;
-import com.fisa.bank.user.application.service.UserService;
+import com.fisa.bank.user.application.service.reader.UserReader;
 import com.fisa.bank.user.persistence.entity.User;
-import com.fisa.bank.user.persistence.entity.id.UserId;
 
 @Component
 @RequiredArgsConstructor
 public class AccountReader {
 
   private final AccountRepository accountRepository;
-  private final UserService userService;
+  private final UserReader userReader;
 
   public Account getAccountByAccountNumber(String accountNumber) {
     return accountRepository
@@ -34,36 +32,14 @@ public class AccountReader {
         .orElseThrow(AccountNotFoundException::new);
   }
 
-  // 현재 로그인한 사용자가 계좌의 소유자인지 검증 후, 계좌 반환
-  public Account getOwnedAccount(String accountNumber, Long userId) {
-    Account account = getAccountByAccountNumber(accountNumber);
-    Long accountOwnerId = account.getUser().getUserId().getValue();
-
-    if (!accountOwnerId.equals(userId)) {
-      throw new AccessDeniedException();
-    }
-    return account;
-  }
-
-  // 현재 로그인한 사용자가 계좌의 소유자인지 검증 후, 계좌 반환 (비관적 락)
-  public Account getOwnedAccountWithLock(String accountNumber, Long userId) {
-    Account account = getAccountByAccountNumberWithLock(accountNumber);
-    Long accountOwnerId = account.getUser().getUserId().getValue();
-
-    if (!accountOwnerId.equals(userId)) {
-      throw new AccessDeniedException();
-    }
-    return account;
-  }
-
   // 사용자 가져오기
   public User getUserById(Long userId) {
-    return userService.getUserById(UserId.of(userId));
+    return userReader.getUserById(userId);
   }
 
   // 송금용 두 계좌 조회 (데드락 방지를 위해 정렬된 순서로 락 획득)
   public TransferAccountsPair lockTransferAccounts(
-      String fromAccountNumber, String toAccountNumber, Long userId) {
+      String fromAccountNumber, String toAccountNumber) {
     List<String> ordered = List.of(fromAccountNumber, toAccountNumber).stream().sorted().toList();
 
     List<Account> locked = accountRepository.lockTwoAccountsByNumbers(ordered);
@@ -79,11 +55,6 @@ public class AccountReader {
             .filter(a -> a.getAccountNumber().equals(toAccountNumber))
             .findFirst()
             .orElseThrow(() -> new AccountNotFoundException("수취 계좌를 찾을 수 없습니다."));
-
-    Long accountOwnerId = from.getUser().getUserId().getValue();
-    if (!accountOwnerId.equals(userId)) {
-      throw new AccessDeniedException();
-    }
 
     return new TransferAccountsPair(from, to);
   }

--- a/bank/src/main/java/com/fisa/bank/account/presentation/controller/AccountController.java
+++ b/bank/src/main/java/com/fisa/bank/account/presentation/controller/AccountController.java
@@ -40,8 +40,7 @@ public class AccountController {
   @GetMapping("/{accountNumber}")
   public ApiResponse<SuccessBody<AccountDetailResponse>> getAccountDetail(
       @Parameter(description = "계좌 번호", required = true) @PathVariable String accountNumber) {
-    Long userId = requesterInfo.getUserId().getValue();
-    AccountDetailResponse response = accountService.getAccountDetail(accountNumber, userId);
+    AccountDetailResponse response = accountService.getAccountDetail(accountNumber);
     return ApiResponseGenerator.success(ResponseCode.GET, response);
   }
 
@@ -57,8 +56,7 @@ public class AccountController {
   @DeleteMapping("/{accountNumber}")
   public ApiResponse<SuccessBody<Void>> deleteAccount(
       @Parameter(description = "계좌 번호", required = true) @PathVariable String accountNumber) {
-    Long userId = requesterInfo.getUserId().getValue();
-    accountService.deleteAccount(accountNumber, userId);
+    accountService.deleteAccount(accountNumber);
     return ApiResponseGenerator.success(ResponseCode.DELETE);
   }
 }

--- a/bank/src/main/java/com/fisa/bank/account/presentation/controller/AccountTransactionController.java
+++ b/bank/src/main/java/com/fisa/bank/account/presentation/controller/AccountTransactionController.java
@@ -44,9 +44,8 @@ public class AccountTransactionController {
   public ApiResponse<SuccessBody<AccountTransactionResponse>> withdraw(
       @Parameter(description = "계좌 번호", required = true) @PathVariable String accountNumber,
       @Valid @RequestBody AccountWithdrawRequest request) {
-    Long userId = requesterInfo.getUserId().getValue();
     AccountTransactionResponse response =
-        accountTransactionService.withdraw(accountNumber, request, userId);
+        accountTransactionService.withdraw(accountNumber, request);
     return ApiResponseGenerator.success(ResponseCode.UPDATE, response);
   }
 
@@ -55,9 +54,7 @@ public class AccountTransactionController {
   public ApiResponse<SuccessBody<AccountTransactionResponse>> deposit(
       @Parameter(description = "계좌 번호", required = true) @PathVariable String accountNumber,
       @Valid @RequestBody AccountDepositRequest request) {
-    Long userId = requesterInfo.getUserId().getValue();
-    AccountTransactionResponse response =
-        accountTransactionService.deposit(accountNumber, request, userId);
+    AccountTransactionResponse response = accountTransactionService.deposit(accountNumber, request);
     return ApiResponseGenerator.success(ResponseCode.UPDATE, response);
   }
 
@@ -65,8 +62,7 @@ public class AccountTransactionController {
   @PostMapping("/transfer")
   public ApiResponse<SuccessBody<TransferResponse>> transfer(
       @Valid @RequestBody TransferRequest request) {
-    Long userId = requesterInfo.getUserId().getValue();
-    TransferResponse response = accountTransactionService.transfer(request, userId);
+    TransferResponse response = accountTransactionService.transfer(request);
     return ApiResponseGenerator.success(ResponseCode.UPDATE, response);
   }
 
@@ -75,9 +71,7 @@ public class AccountTransactionController {
   public ApiResponse<SuccessBody<CardPaymentResponse>> pay(
       @Parameter(description = "계좌 번호", required = true) @PathVariable String accountNumber,
       @Valid @RequestBody CardPaymentRequest request) {
-    Long userId = requesterInfo.getUserId().getValue();
-    CardPaymentResponse response =
-        accountTransactionService.payByCard(accountNumber, request, userId);
+    CardPaymentResponse response = accountTransactionService.payByCard(accountNumber, request);
     return ApiResponseGenerator.success(ResponseCode.UPDATE, response);
   }
 
@@ -89,9 +83,8 @@ public class AccountTransactionController {
           LocalDate startDate,
       @Parameter(description = "조회 종료일 (YYYY-MM-DD)", required = true) @RequestParam
           LocalDate endDate) {
-    Long userId = requesterInfo.getUserId().getValue();
     AccountTransactionListResponse response =
-        accountTransactionService.getTransactions(accountNumber, startDate, endDate, userId);
+        accountTransactionService.getTransactions(accountNumber, startDate, endDate);
     return ApiResponseGenerator.success(ResponseCode.GET, response);
   }
 }

--- a/bank/src/main/java/com/fisa/bank/common/aop/annotation/DomainType.java
+++ b/bank/src/main/java/com/fisa/bank/common/aop/annotation/DomainType.java
@@ -1,0 +1,6 @@
+package com.fisa.bank.common.aop.annotation;
+
+public enum DomainType {
+  ACCOUNT,
+  LOAN
+}

--- a/bank/src/main/java/com/fisa/bank/common/aop/annotation/VerifyOwner.java
+++ b/bank/src/main/java/com/fisa/bank/common/aop/annotation/VerifyOwner.java
@@ -1,0 +1,11 @@
+package com.fisa.bank.common.aop.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface VerifyOwner {
+  DomainType domain(); // 도메인 구분용
+
+  String idParam() default "userId"; // 메서드 또는 DTO에서 찾을 파라미터 이름
+}

--- a/bank/src/main/java/com/fisa/bank/common/aop/aspect/OwnershipAspect.java
+++ b/bank/src/main/java/com/fisa/bank/common/aop/aspect/OwnershipAspect.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Field;
 
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.*;
+import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.stereotype.Component;
 
 import com.fisa.bank.account.application.exception.AccessDeniedException;
@@ -42,22 +43,26 @@ public class OwnershipAspect {
   }
 
   private Object extractParamValue(JoinPoint joinPoint, String paramName) {
-    for (Object arg : joinPoint.getArgs()) {
+    MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+    String[] parameterNames = signature.getParameterNames();
+    Object[] args = joinPoint.getArgs();
+
+    for (int i = 0; i < parameterNames.length; i++) {
+      if (parameterNames[i].equals(paramName)) {
+        return args[i];
+      }
+    }
+
+    for (Object arg : args) {
       if (arg == null) continue;
-
-      // 직접 파라미터로 전달된 경우
-      if (arg instanceof String && paramName.equals("accountNumber")) return arg;
-      if (arg instanceof Long && paramName.equals("loanId")) return arg;
-
-      // DTO나 record에서 필드 추출
       try {
-        for (Field f : arg.getClass().getDeclaredFields()) {
-          if (f.getName().equals(paramName)) {
-            f.setAccessible(true);
-            return f.get(arg);
-          }
-        }
-      } catch (IllegalAccessException ignored) {
+        Field field = arg.getClass().getDeclaredField(paramName);
+        field.setAccessible(true);
+        return field.get(arg);
+      } catch (NoSuchFieldException ignored) {
+        // Not in this arg, continue.
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException("Failed to access field: " + paramName, e);
       }
     }
     throw new IllegalArgumentException(paramName + " 파라미터를 찾을 수 없습니다.");

--- a/bank/src/main/java/com/fisa/bank/common/aop/aspect/OwnershipAspect.java
+++ b/bank/src/main/java/com/fisa/bank/common/aop/aspect/OwnershipAspect.java
@@ -1,0 +1,65 @@
+package com.fisa.bank.common.aop.aspect;
+
+import lombok.RequiredArgsConstructor;
+
+import java.lang.reflect.Field;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.springframework.stereotype.Component;
+
+import com.fisa.bank.account.application.exception.AccessDeniedException;
+import com.fisa.bank.account.application.service.reader.AccountReader;
+import com.fisa.bank.account.persistence.entity.Account;
+import com.fisa.bank.common.aop.annotation.VerifyOwner;
+import com.fisa.bank.common.application.util.RequesterInfo;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class OwnershipAspect {
+
+  private final AccountReader accountReader;
+  private final RequesterInfo requesterInfo;
+
+  @Before("@annotation(verifyOwner)")
+  public void verifyOwnership(JoinPoint joinPoint, VerifyOwner verifyOwner) {
+    Object idValue = extractParamValue(joinPoint, verifyOwner.idParam());
+
+    switch (verifyOwner.domain()) {
+      case ACCOUNT -> {
+        Account account = accountReader.getAccountByAccountNumber(idValue.toString());
+        if (!account
+            .getUser()
+            .getUserId()
+            .getValue()
+            .equals(requesterInfo.getUserId().getValue())) {
+          throw new AccessDeniedException();
+        }
+      }
+      case LOAN -> {}
+    }
+  }
+
+  private Object extractParamValue(JoinPoint joinPoint, String paramName) {
+    for (Object arg : joinPoint.getArgs()) {
+      if (arg == null) continue;
+
+      // 직접 파라미터로 전달된 경우
+      if (arg instanceof String && paramName.equals("accountNumber")) return arg;
+      if (arg instanceof Long && paramName.equals("loanId")) return arg;
+
+      // DTO나 record에서 필드 추출
+      try {
+        for (Field f : arg.getClass().getDeclaredFields()) {
+          if (f.getName().equals(paramName)) {
+            f.setAccessible(true);
+            return f.get(arg);
+          }
+        }
+      } catch (IllegalAccessException ignored) {
+      }
+    }
+    throw new IllegalArgumentException(paramName + " 파라미터를 찾을 수 없습니다.");
+  }
+}

--- a/bank/src/main/java/com/fisa/bank/common/presentation/response/code/BusinessErrorCode.java
+++ b/bank/src/main/java/com/fisa/bank/common/presentation/response/code/BusinessErrorCode.java
@@ -21,14 +21,18 @@ import com.fisa.bank.user.application.exception.UserNotFoundException;
 public enum BusinessErrorCode implements ErrorResponseCode<BusinessException> {
 
   /** 여기에 커스텀 BusinessException을 정의하면 됩니다. */
+  // Auth
   INVALID_PASSWORD_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, InvalidPasswordFormatException.class),
   INVALID_AUTH_INFO_EXCEPTION(HttpStatus.BAD_REQUEST, InvalidAuthInfoException.class),
+  // Account
   ACCOUNT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, AccountNotFoundException.class),
   INSUFFICIENT_BALANCE_EXCEPTION(HttpStatus.BAD_REQUEST, InsufficientBalanceException.class),
-  USER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, UserNotFoundException.class),
   ACCOUNT_OWNER_MISMATCH_EXCEPTION(HttpStatus.BAD_REQUEST, AccountOwnerMismatchException.class),
-  LOAN_PRODUCT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, LoanProductNotFoundException.class),
   ACCOUNT_NOT_DELETABLE_EXCEPTION(HttpStatus.BAD_REQUEST, AccountNotDeletableException.class),
+  ACCESSS_DENIED_EXCEPTION(HttpStatus.BAD_REQUEST, AccessDeniedException.class),
+  INVALID_TRANSFER_TARGET_EXCEPTION(HttpStatus.BAD_REQUEST, InvalidTransferTargetException.class),
+  // Loan
+  LOAN_PRODUCT_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, LoanProductNotFoundException.class),
   INTEREST_EXCEPTION(HttpStatus.NOT_FOUND, InterestException.class),
   DUPLICATE_LOAN_EXCEPTION(HttpStatus.CONFLICT, DuplicateLoanException.class),
   INSUFFICIENT_REPAYMENT_EXCEPTION(
@@ -36,9 +40,9 @@ public enum BusinessErrorCode implements ErrorResponseCode<BusinessException> {
   PREFER_INTEREST_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, PreferInterestNotFoundException.class),
   LOAN_LEDGER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, LoanLedgerNotFoundException.class),
   LOAN_LEDGER_ACCESS_DENIED_EXCEPTION(HttpStatus.FORBIDDEN, LoanLedgerAccessDeniedException.class),
-  UNKNOWN_CALCULATOR_EXCEPTION(HttpStatus.BAD_REQUEST, UnknownCalculatorException.class),
-  INSUFFICIENT_BALANCE_AMOUNT_EXCEPTION(
-      HttpStatus.UNPROCESSABLE_ENTITY, InsufficientBalanceAmountException.class);
+  // user
+  USER_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, UserNotFoundException.class);
+
   private final HttpStatus status;
   @Getter private final Class<? extends BusinessException> exception;
 

--- a/bank/src/main/java/com/fisa/bank/user/application/service/UserService.java
+++ b/bank/src/main/java/com/fisa/bank/user/application/service/UserService.java
@@ -51,12 +51,8 @@ public class UserService {
   }
 
   public UserInfoResponse getUserInfo(UserId userId) {
-    User user = getUserById(userId);
+    User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
     return UserInfoResponse.of(user);
-  }
-
-  public User getUserById(UserId userId) {
-    return userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
   }
 }

--- a/bank/src/main/java/com/fisa/bank/user/application/service/UserService.java
+++ b/bank/src/main/java/com/fisa/bank/user/application/service/UserService.java
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fisa.bank.user.application.dto.UserCreateRequest;
 import com.fisa.bank.user.application.dto.UserInfoResponse;
 import com.fisa.bank.user.application.exception.InvalidAuthInfoException;
-import com.fisa.bank.user.application.exception.UserNotFoundException;
+import com.fisa.bank.user.application.service.reader.UserReader;
 import com.fisa.bank.user.application.util.PasswordUtil;
 import com.fisa.bank.user.persistence.entity.User;
 import com.fisa.bank.user.persistence.entity.UserAuth;
@@ -24,6 +24,7 @@ public class UserService {
 
   private final UserRepository userRepository;
   private final UserAuthRepository authRepository;
+  private final UserReader userReader;
   private final PasswordUtil passwordUtil;
 
   @Transactional
@@ -51,7 +52,7 @@ public class UserService {
   }
 
   public UserInfoResponse getUserInfo(UserId userId) {
-    User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+    User user = userReader.getUserById(userId.getValue());
 
     return UserInfoResponse.of(user);
   }

--- a/bank/src/main/java/com/fisa/bank/user/application/service/reader/UserReader.java
+++ b/bank/src/main/java/com/fisa/bank/user/application/service/reader/UserReader.java
@@ -1,0 +1,20 @@
+package com.fisa.bank.user.application.service.reader;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Component;
+
+import com.fisa.bank.user.application.exception.UserNotFoundException;
+import com.fisa.bank.user.persistence.entity.User;
+import com.fisa.bank.user.persistence.entity.id.UserId;
+import com.fisa.bank.user.persistence.repository.UserRepository;
+
+@Component
+@RequiredArgsConstructor
+public class UserReader {
+  private final UserRepository userRepository;
+
+  public User getUserById(Long userId) {
+    return userRepository.findById(UserId.of(userId)).orElseThrow(UserNotFoundException::new);
+  }
+}


### PR DESCRIPTION
## 관련 이슈
- #75 

## 기능 
- 기존 service에서 검증했던 부분을 분리 
-> userId를 service에서 처리하지 않게 함 (계좌 생성, 계좌 조회 등만 파라미터로 userId를 받음)
- 소유권 검증 로직을 AOP로 처리 

## 공유사항 
- Loan 도메인 부분의 소유권 처리 로직도 분리해야 함. 팀원에게 공유하고 진행할 예정 