### PR TITLE
[REFACTOR] loan 도메인 소유권 검증 로직

### DIFF
--- a/bank/src/main/java/com/fisa/bank/common/aop/aspect/OwnershipAspect.java
+++ b/bank/src/main/java/com/fisa/bank/common/aop/aspect/OwnershipAspect.java
@@ -26,7 +26,7 @@ import com.fisa.bank.loan.persistence.repository.LoanLedgerRepository;
 public class OwnershipAspect {
 
   private final AccountReader accountReader;
-  private final LoanLedgerRepository loanLedgerRepository;
+  private final LoanReader loanReader;
   private final RequesterInfo requesterInfo;
 
   @Before("@annotation(verifyOwner)")

--- a/bank/src/main/java/com/fisa/bank/common/aop/aspect/OwnershipAspect.java
+++ b/bank/src/main/java/com/fisa/bank/common/aop/aspect/OwnershipAspect.java
@@ -14,6 +14,11 @@ import com.fisa.bank.account.application.service.reader.AccountReader;
 import com.fisa.bank.account.persistence.entity.Account;
 import com.fisa.bank.common.aop.annotation.VerifyOwner;
 import com.fisa.bank.common.application.util.RequesterInfo;
+import com.fisa.bank.loan.application.exception.LoanLedgerAccessDeniedException;
+import com.fisa.bank.loan.application.exception.LoanLedgerNotFoundException;
+import com.fisa.bank.loan.persistence.entity.LoanLedger;
+import com.fisa.bank.loan.persistence.entity.id.LoanLedgerId;
+import com.fisa.bank.loan.persistence.repository.LoanLedgerRepository;
 
 @Aspect
 @Component
@@ -21,6 +26,7 @@ import com.fisa.bank.common.application.util.RequesterInfo;
 public class OwnershipAspect {
 
   private final AccountReader accountReader;
+  private final LoanLedgerRepository loanLedgerRepository;
   private final RequesterInfo requesterInfo;
 
   @Before("@annotation(verifyOwner)")
@@ -38,7 +44,20 @@ public class OwnershipAspect {
           throw new AccessDeniedException();
         }
       }
-      case LOAN -> {}
+      case LOAN -> {
+        Long loanLedgerId = ((Number) idValue).longValue();
+        LoanLedger loanLedger =
+            loanLedgerRepository
+                .findById(LoanLedgerId.of(loanLedgerId))
+                .orElseThrow(() -> new LoanLedgerNotFoundException(loanLedgerId));
+        if (!loanLedger
+            .getUser()
+            .getUserId()
+            .getValue()
+            .equals(requesterInfo.getUserId().getValue())) {
+          throw new LoanLedgerAccessDeniedException();
+        }
+      }
     }
   }
 

--- a/bank/src/main/java/com/fisa/bank/common/aop/aspect/OwnershipAspect.java
+++ b/bank/src/main/java/com/fisa/bank/common/aop/aspect/OwnershipAspect.java
@@ -46,10 +46,7 @@ public class OwnershipAspect {
       }
       case LOAN -> {
         Long loanLedgerId = ((Number) idValue).longValue();
-        LoanLedger loanLedger =
-            loanLedgerRepository
-                .findById(LoanLedgerId.of(loanLedgerId))
-                .orElseThrow(() -> new LoanLedgerNotFoundException(loanLedgerId));
+        LoanLedger loanLedger = loanReader.getLoanLedgerById(loanLedgerId);
         if (!loanLedger
             .getUser()
             .getUserId()

--- a/bank/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/bank/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -5,16 +5,16 @@ import lombok.RequiredArgsConstructor;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.fisa.bank.account.application.exception.AccountNotFoundException;
+import com.fisa.bank.account.application.service.reader.AccountReader;
 import com.fisa.bank.account.persistence.entity.Account;
-import com.fisa.bank.account.persistence.repository.AccountRepository;
+import com.fisa.bank.common.aop.annotation.DomainType;
+import com.fisa.bank.common.aop.annotation.VerifyOwner;
 import com.fisa.bank.common.application.util.RequesterInfo;
 import com.fisa.bank.interest.application.dto.response.InterestRateResponse;
 import com.fisa.bank.interest.application.service.InterestService;
@@ -22,27 +22,33 @@ import com.fisa.bank.interest.persistence.entity.InterestRate;
 import com.fisa.bank.loan.application.dto.request.LoanApplyForRequest;
 import com.fisa.bank.loan.application.dto.request.LoanMonthlyRepayRequest;
 import com.fisa.bank.loan.application.dto.request.LoanProductCreateRequest;
-import com.fisa.bank.loan.application.dto.response.*;
+import com.fisa.bank.loan.application.dto.response.LoanApplyforResponse;
+import com.fisa.bank.loan.application.dto.response.LoanLedgerDetailResponse;
+import com.fisa.bank.loan.application.dto.response.LoanLedgerResponse;
+import com.fisa.bank.loan.application.dto.response.LoanProductCreateResponse;
+import com.fisa.bank.loan.application.dto.response.LoanProductResponse;
+import com.fisa.bank.loan.application.dto.response.LoanTransactionResponse;
+import com.fisa.bank.loan.application.dto.response.PagedResponse;
 import com.fisa.bank.loan.application.exception.*;
 import com.fisa.bank.loan.application.model.EarlyRepayment;
 import com.fisa.bank.loan.application.model.MonthlyRepayment;
 import com.fisa.bank.loan.application.model.UpdateLoanLedgerParam;
 import com.fisa.bank.loan.application.service.calculator.CalculatorService;
+import com.fisa.bank.loan.application.service.reader.LoanReader;
 import com.fisa.bank.loan.application.util.EarlyRepayInterestRate;
 import com.fisa.bank.loan.application.util.LoanTransactionFactory;
 import com.fisa.bank.loan.persistence.entity.*;
-import com.fisa.bank.loan.persistence.entity.id.LoanLedgerId;
 import com.fisa.bank.loan.persistence.entity.id.LoanProductId;
 import com.fisa.bank.loan.persistence.enums.*;
 import com.fisa.bank.loan.persistence.repository.LoanLedgerRepository;
 import com.fisa.bank.loan.persistence.repository.LoanRepository;
 import com.fisa.bank.loan.persistence.repository.LoanTransactionRepository;
 import com.fisa.bank.loan.persistence.repository.PreferInterestRepository;
+import com.fisa.bank.user.application.service.reader.UserReader;
 import com.fisa.bank.user.persistence.entity.CreditRating;
 import com.fisa.bank.user.persistence.entity.CustomerLevel;
 import com.fisa.bank.user.persistence.entity.User;
 import com.fisa.bank.user.persistence.entity.id.UserId;
-import com.fisa.bank.user.persistence.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -50,12 +56,13 @@ public class LoanService {
   private final LoanRepository loanRepository;
   private final InterestService interestService;
   private final PreferInterestRepository preferInterestRepository;
-  private final UserRepository userRepository;
+  private final UserReader userReader;
   private final LoanLedgerRepository loanLedgerRepository;
   private final LoanTransactionRepository loanTransactionRepository;
-  private final RequesterInfo requesterInfo;
-  private final AccountRepository accountRepository;
+  private final AccountReader accountReader;
   private final CalculatorService calculatorService;
+  private final LoanReader loanReader;
+  private final RequesterInfo requesterInfo;
 
   @Transactional
   public LoanProductCreateResponse createLoanProduct(LoanProductCreateRequest requestDTO) {
@@ -80,6 +87,7 @@ public class LoanService {
     return response;
   }
 
+  // TODO: 추후 soft-delete로 바꿀 예정
   @Transactional
   public void deleteLoanProduct(Long loanProductId) {
     // 있는지 확인 후
@@ -90,49 +98,13 @@ public class LoanService {
   }
 
   @Transactional
-  public PagedResponse<LoanProductResponse<LoanProduct>> findAllProducts(Pageable pageable) {
-    Page<LoanProduct> productPage = loanRepository.findAll(pageable);
-
-    Page<LoanProductResponse<LoanProduct>> response =
-        productPage.map(
-            (loanProduct) -> {
-              InterestRate interestRate = loanProduct.getInterestRateList().get(0);
-              InterestRateResponse interestRateResponse = InterestRateResponse.from(interestRate);
-              return LoanProductResponse.from(loanProduct, interestRateResponse);
-            });
-
-    return new PagedResponse<>(response);
-  }
-
-  @Transactional
-  public LoanProductResponse<LoanProduct> findProductById(Long loanProductId) {
-
-    LoanProduct loanProduct =
-        loanRepository
-            .findById(LoanProductId.of(loanProductId))
-            .orElseThrow(() -> new LoanProductNotFoundException(loanProductId));
-
-    InterestRateResponse interestRateResponse =
-        InterestRateResponse.from(loanProduct.getInterestRateList().get(0));
-
-    LoanProductResponse<LoanProduct> response =
-        LoanProductResponse.from(loanProduct, interestRateResponse);
-
-    return response;
-  }
-
-  @Transactional
+  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")
   public LoanApplyforResponse applyForLoan(LoanApplyForRequest request, Long loanProductId) {
-
-    // 유저 정보 추출
     UserId userId = requesterInfo.getUserId();
-    User user = userRepository.getReferenceById(userId);
-    Account account =
-        accountRepository
-            .findByAccountNumber(request.getAccountNumber())
-            .orElseThrow(AccountNotFoundException::new);
-    if (loanLedgerRepository.existsByUser_UserIdAndLoanProduct_LoanProductId(
-        userId, LoanProductId.of(loanProductId))) {
+    // 유저 정보 추출
+    User user = userReader.getUserById(userId.getValue());
+    Account account = accountReader.getAccountByAccountNumber(request.getAccountNumber());
+    if (loanReader.existsByUserIdAndLoanProductId(userId.getValue(), loanProductId)) {
       throw new DuplicateLoanException(userId, LoanProductId.of(loanProductId));
     }
 
@@ -141,10 +113,7 @@ public class LoanService {
     BigDecimal remainPrincipal = request.getPrincipal();
 
     // 대출 유형 - 대출 상품에서 조회
-    LoanProduct loanProduct =
-        loanRepository
-            .findById(LoanProductId.of(loanProductId))
-            .orElseThrow(() -> new LoanProductNotFoundException(loanProductId));
+    LoanProduct loanProduct = loanReader.findProductById(loanProductId);
     LoanType loanType = loanProduct.getType();
     InterestType interestType = request.getInterestType();
 
@@ -235,13 +204,11 @@ public class LoanService {
   }
 
   @Transactional
+  @VerifyOwner(domain = DomainType.LOAN, idParam = "loanLedgerId")
   public LoanTransactionResponse repayMonthlyLoan(
       Long loanLedgerId, LoanMonthlyRepayRequest request) {
 
-    LoanLedger loanLedger =
-        loanLedgerRepository
-            .findById(LoanLedgerId.of(loanLedgerId))
-            .orElseThrow(() -> new LoanLedgerNotFoundException(loanLedgerId));
+    LoanLedger loanLedger = loanReader.getLoanLedgerById(loanLedgerId);
 
     MonthlyRepayment monthlyRepayment = calculatorService.calculate(loanLedger);
 
@@ -288,20 +255,13 @@ public class LoanService {
   }
 
   @Transactional
+  @VerifyOwner(domain = DomainType.LOAN, idParam = "loanLedgerId")
   public void cancelLoan(Long loanLedgerId) {
     LocalDateTime today = LocalDateTime.now();
-    UserId userId = requesterInfo.getUserId();
 
-    LoanLedger loanLedger =
-        loanLedgerRepository
-            .findById(LoanLedgerId.of(loanLedgerId))
-            .orElseThrow(() -> new LoanLedgerNotFoundException(loanLedgerId));
+    LoanLedger loanLedger = loanReader.getLoanLedgerById(loanLedgerId);
 
-    UserId userIdOfLedger = loanLedger.getUser().getUserId();
     Account account = loanLedger.getAccount();
-
-    // 내 대출인지 확인
-    if (!userIdOfLedger.equals(userId)) throw new LoanLedgerAccessDeniedException();
 
     // 수수료율
     BigDecimal earlyPaidRate = loanLedger.getEarlyRepayInterestRate();
@@ -334,34 +294,42 @@ public class LoanService {
   }
 
   @Transactional(readOnly = true)
-  public LoanLedgerDetailResponse getLoanLedgerDetail(Long loanLedgerId) {
-    // 대출 이름, 남은 원금, 원금, 월 상환액, 상환 계좌, 대출 유형, 상환 방식 응답
-    LoanLedger loanLedger =
-        loanLedgerRepository
-            .findById(LoanLedgerId.of(loanLedgerId))
-            .orElseThrow(() -> new LoanLedgerNotFoundException(loanLedgerId));
-    UserId userIdOfLoanLedger = loanLedger.getUser().getUserId();
+  public PagedResponse<LoanProductResponse<LoanProduct>> getAllProducts(Pageable pageable) {
+    Page<LoanProduct> productPage = loanReader.findAllProducts(pageable);
 
-    UserId userId = requesterInfo.getUserId();
-    // 대출한 유저의 id와 로그인한 유저의 id 비교
-    if (!userIdOfLoanLedger.equals(userId)) {
-      throw new LoanLedgerAccessDeniedException();
-    }
+    Page<LoanProductResponse<LoanProduct>> responsePage =
+        productPage.map(
+            loanProduct -> {
+              InterestRate interestRate = loanProduct.getInterestRateList().get(0);
+              InterestRateResponse interestRateResponse = InterestRateResponse.from(interestRate);
+              return LoanProductResponse.from(loanProduct, interestRateResponse);
+            });
+
+    return new PagedResponse<>(responsePage);
+  }
+
+  @Transactional(readOnly = true)
+  public LoanProductResponse<LoanProduct> getProductById(Long loanProductId) {
+    LoanProduct loanProduct = loanReader.findProductById(loanProductId);
+
+    InterestRateResponse interestRateResponse =
+        InterestRateResponse.from(loanProduct.getInterestRateList().get(0));
+
+    return LoanProductResponse.from(loanProduct, interestRateResponse);
+  }
+
+  @Transactional(readOnly = true)
+  @VerifyOwner(domain = DomainType.LOAN, idParam = "loanLedgerId")
+  public LoanLedgerDetailResponse getLoanLedgerDetail(Long loanLedgerId) {
+    LoanLedger loanLedger = loanReader.getLoanLedgerById(loanLedgerId);
 
     MonthlyRepayment monthlyRepayment = calculatorService.calculate(loanLedger);
     return LoanLedgerDetailResponse.from(loanLedger, monthlyRepayment);
   }
 
   @Transactional(readOnly = true)
-  public List<LoanLedgerResponse> getMyLoanLedger(Long userId) {
-
-    Long userIdLogin = requesterInfo.getUserId().getValue();
-    if (!Objects.equals(userIdLogin, userId)) {
-      throw new LoanLedgerAccessDeniedException();
-    }
-
-    List<LoanLedger> allLoanLedgers = loanLedgerRepository.findAllByUser_UserId(UserId.of(userId));
-
-    return allLoanLedgers.stream().map(LoanLedgerResponse::from).toList();
+  public List<LoanLedgerResponse> getMyLoanLedgers(Long userId) {
+    List<LoanLedger> loanLedgers = loanReader.findAllByUserId(userId);
+    return loanLedgers.stream().map(LoanLedgerResponse::from).toList();
   }
 }

--- a/bank/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/bank/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -208,7 +208,7 @@ public class LoanService {
   public LoanTransactionResponse repayMonthlyLoan(
       Long loanLedgerId, LoanMonthlyRepayRequest request) {
 
-    LoanLedger loanLedger = loanReader.getLoanLedgerById(loanLedgerId);
+    LoanLedger loanLedger = loanReader.findLoanLedgerById(loanLedgerId);
 
     MonthlyRepayment monthlyRepayment = calculatorService.calculate(loanLedger);
 
@@ -259,7 +259,7 @@ public class LoanService {
   public void cancelLoan(Long loanLedgerId) {
     LocalDateTime today = LocalDateTime.now();
 
-    LoanLedger loanLedger = loanReader.getLoanLedgerById(loanLedgerId);
+    LoanLedger loanLedger = loanReader.findLoanLedgerById(loanLedgerId);
 
     Account account = loanLedger.getAccount();
 
@@ -321,7 +321,7 @@ public class LoanService {
   @Transactional(readOnly = true)
   @VerifyOwner(domain = DomainType.LOAN, idParam = "loanLedgerId")
   public LoanLedgerDetailResponse getLoanLedgerDetail(Long loanLedgerId) {
-    LoanLedger loanLedger = loanReader.getLoanLedgerById(loanLedgerId);
+    LoanLedger loanLedger = loanReader.findLoanLedgerById(loanLedgerId);
 
     MonthlyRepayment monthlyRepayment = calculatorService.calculate(loanLedger);
     return LoanLedgerDetailResponse.from(loanLedger, monthlyRepayment);

--- a/bank/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
+++ b/bank/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
@@ -36,7 +36,7 @@ public class LoanReader {
         .orElseThrow(() -> new LoanProductNotFoundException(loanProductId));
   }
 
-  public LoanLedger getLoanLedgerById(Long loanLedgerId) {
+  public LoanLedger findLoanLedgerById(Long loanLedgerId) {
     return loanLedgerRepository
         .findById(LoanLedgerId.of(loanLedgerId))
         .orElseThrow(() -> new LoanLedgerNotFoundException(loanLedgerId));

--- a/bank/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
+++ b/bank/src/main/java/com/fisa/bank/loan/application/service/reader/LoanReader.java
@@ -1,0 +1,53 @@
+package com.fisa.bank.loan.application.service.reader;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fisa.bank.loan.application.exception.LoanLedgerNotFoundException;
+import com.fisa.bank.loan.application.exception.LoanProductNotFoundException;
+import com.fisa.bank.loan.persistence.entity.LoanLedger;
+import com.fisa.bank.loan.persistence.entity.LoanProduct;
+import com.fisa.bank.loan.persistence.entity.id.LoanLedgerId;
+import com.fisa.bank.loan.persistence.entity.id.LoanProductId;
+import com.fisa.bank.loan.persistence.repository.LoanLedgerRepository;
+import com.fisa.bank.loan.persistence.repository.LoanRepository;
+import com.fisa.bank.user.persistence.entity.id.UserId;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LoanReader {
+  private final LoanRepository loanRepository;
+  private final LoanLedgerRepository loanLedgerRepository;
+
+  public Page<LoanProduct> findAllProducts(Pageable pageable) {
+    return loanRepository.findAll(pageable);
+  }
+
+  public LoanProduct findProductById(Long loanProductId) {
+    return loanRepository
+        .findById(LoanProductId.of(loanProductId))
+        .orElseThrow(() -> new LoanProductNotFoundException(loanProductId));
+  }
+
+  public LoanLedger getLoanLedgerById(Long loanLedgerId) {
+    return loanLedgerRepository
+        .findById(LoanLedgerId.of(loanLedgerId))
+        .orElseThrow(() -> new LoanLedgerNotFoundException(loanLedgerId));
+  }
+
+  public List<LoanLedger> findAllByUserId(Long userId) {
+    return loanLedgerRepository.findAllByUser_UserId(UserId.of(userId));
+  }
+
+  public boolean existsByUserIdAndLoanProductId(Long userId, Long loanProductId) {
+    return loanLedgerRepository.existsByUser_UserIdAndLoanProduct_LoanProductId(
+        UserId.of(userId), LoanProductId.of(loanProductId));
+  }
+}

--- a/bank/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
+++ b/bank/src/main/java/com/fisa/bank/loan/presentation/controller/LoanController.java
@@ -10,7 +10,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
-import com.fisa.bank.common.application.util.RequesterInfo;
 import com.fisa.bank.common.presentation.response.ApiResponse;
 import com.fisa.bank.common.presentation.response.ApiResponseGenerator;
 import com.fisa.bank.common.presentation.response.body.SuccessBody;
@@ -29,7 +28,6 @@ import com.fisa.bank.loan.persistence.entity.LoanProduct;
 public class LoanController {
 
   private final LoanService loanService;
-  private final RequesterInfo requesterInfo;
 
   // 은행
   @PostMapping
@@ -46,7 +44,7 @@ public class LoanController {
       @PageableDefault(page = 0, size = 10) Pageable pageable) {
 
     PagedResponse<LoanProductResponse<LoanProduct>> allProducts =
-        loanService.findAllProducts(pageable);
+        loanService.getAllProducts(pageable);
 
     return ApiResponseGenerator.success(ResponseCode.GET, allProducts);
   }
@@ -54,7 +52,7 @@ public class LoanController {
   @GetMapping("/{loanProductId}")
   public ApiResponse<SuccessBody<LoanProductResponse<LoanProduct>>> getLoanProductById(
       @PathVariable Long loanProductId) {
-    LoanProductResponse<LoanProduct> loanProduct = loanService.findProductById(loanProductId);
+    LoanProductResponse<LoanProduct> loanProduct = loanService.getProductById(loanProductId);
 
     return ApiResponseGenerator.success(ResponseCode.GET, loanProduct);
   }
@@ -99,7 +97,7 @@ public class LoanController {
   public ApiResponse<SuccessBody<List<LoanLedgerResponse>>> getMyLoanLedgers(
       @PathVariable Long userId) {
     log.info("대출 리스트 조회");
-    List<LoanLedgerResponse> myLoanLedger = loanService.getMyLoanLedger(userId);
+    List<LoanLedgerResponse> myLoanLedger = loanService.getMyLoanLedgers(userId);
 
     return ApiResponseGenerator.success(ResponseCode.GET, myLoanLedger);
   }


### PR DESCRIPTION
## 관련 이슈
- #74 

## 기능
- loanService에 중복되는 단순 조회 로직 LoanReader로 분리 
- 소유권 검증 로직 aop로 분리
- 상품 가입할 때 계좌번호가 현재 로그인한 사람의 소유가 맞는지 검증하는 로직 추가 
- userRepository, accountRepository 대신 reader 패키지 사용 

