### PR TITLE
[fix, refactor] 계좌 도메인 qa 수정

### DIFF
--- a/bank/src/main/java/com/fisa/bank/account/application/dto/response/AccountResponse.java
+++ b/bank/src/main/java/com/fisa/bank/account/application/dto/response/AccountResponse.java
@@ -2,9 +2,11 @@ package com.fisa.bank.account.application.dto.response;
 
 import com.fisa.bank.account.persistence.entity.Account;
 
-public record AccountResponse(String accountNumber, String bankCode, String message) {
+public record AccountResponse(
+    Long accountId, String accountNumber, String bankCode, String message) {
 
   public static AccountResponse from(Account entity, String message) {
-    return new AccountResponse(entity.getAccountNumber(), entity.getBankCode(), message);
+    return new AccountResponse(
+        entity.getAccountId().getValue(), entity.getAccountNumber(), entity.getBankCode(), message);
   }
 }

--- a/bank/src/main/java/com/fisa/bank/account/application/dto/response/AccountTransactionListResponse.java
+++ b/bank/src/main/java/com/fisa/bank/account/application/dto/response/AccountTransactionListResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 /** 계좌 거래내역 전체 응답 DTO */
 public record AccountTransactionListResponse(
-    String accountNumber, // 계좌 ID
+    Long accountId, // 계좌 ID
+    String accountNumber, // 계좌 번호
     List<AccountTransactionResponse> transactions // 거래내역 리스트
     ) {}

--- a/bank/src/main/java/com/fisa/bank/account/application/dto/response/AccountTransactionResponse.java
+++ b/bank/src/main/java/com/fisa/bank/account/application/dto/response/AccountTransactionResponse.java
@@ -7,7 +7,7 @@ import com.fisa.bank.account.persistence.entity.AccountTransaction;
 
 /** 단일 거래내역 응답 DTO */
 public record AccountTransactionResponse(
-    String trxId, // 거래 ID
+    Long trxId, // 거래 ID
     LocalDateTime date, // 거래 일시
     String type, // 거래 유형 (DEPOSIT, WITHDRAWAL 등)
     BigDecimal amount, // 거래 금액
@@ -16,8 +16,8 @@ public record AccountTransactionResponse(
 
   public static AccountTransactionResponse from(AccountTransaction transaction) {
     return new AccountTransactionResponse(
-        transaction.getTrxAId().getValue().toString(),
-        transaction.getDate(),
+        transaction.getTrxAId().getValue(),
+        transaction.getCreatedAt(),
         transaction.getType().name(),
         transaction.getAmount(),
         transaction.getBalanceAfter());

--- a/bank/src/main/java/com/fisa/bank/account/application/dto/response/CardPaymentResponse.java
+++ b/bank/src/main/java/com/fisa/bank/account/application/dto/response/CardPaymentResponse.java
@@ -8,7 +8,6 @@ import com.fisa.bank.account.persistence.enums.ConsumptionCategory;
 
 public record CardPaymentResponse(
     Long trxCId,
-    Long accountId,
     String storeName,
     BigDecimal amount,
     ConsumptionCategory category,
@@ -19,7 +18,6 @@ public record CardPaymentResponse(
   public static CardPaymentResponse from(CardTransaction trx) {
     return new CardPaymentResponse(
         trx.getTrxCId().getValue(),
-        trx.getAccount().getAccountId().getValue(),
         trx.getStoreName(),
         trx.getAmount(),
         trx.getCategory(),

--- a/bank/src/main/java/com/fisa/bank/account/application/dto/response/TransferResponse.java
+++ b/bank/src/main/java/com/fisa/bank/account/application/dto/response/TransferResponse.java
@@ -1,6 +1,7 @@
 package com.fisa.bank.account.application.dto.response;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 import com.fisa.bank.account.persistence.entity.Account;
 
@@ -10,6 +11,7 @@ public record TransferResponse(
     BigDecimal amount,
     BigDecimal fromBalanceAfter,
     BigDecimal toBalanceAfter,
+    LocalDateTime transactionAt,
     String message) {
 
   // 같은 은행끼리 거래 시 팩토리 메서드
@@ -20,6 +22,7 @@ public record TransferResponse(
         amount,
         fromAccount.getBalance(),
         toAccount.getBalance(),
+        LocalDateTime.now(),
         "이체가 성공적으로 완료되었습니다.");
   }
 
@@ -32,6 +35,7 @@ public record TransferResponse(
         amount,
         fromAccount.getBalance(),
         null, // 타행이므로 잔액 알 수 없음
+        LocalDateTime.now(),
         "타행 이체가 성공적으로 완료되었습니다.");
   }
 }

--- a/bank/src/main/java/com/fisa/bank/account/application/listener/AccountTransactionListener.java
+++ b/bank/src/main/java/com/fisa/bank/account/application/listener/AccountTransactionListener.java
@@ -1,0 +1,28 @@
+package com.fisa.bank.account.application.listener;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.fisa.bank.account.application.service.AccountDomainManager;
+import com.fisa.bank.account.persistence.entity.Account;
+import com.fisa.bank.account.persistence.enums.TransactionType;
+import com.fisa.bank.loan.application.event.LoanRepaidEvent;
+
+@Component
+@RequiredArgsConstructor
+public class AccountTransactionListener {
+
+  private final AccountDomainManager accountDomainManager;
+
+  @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+  public void handleLoanRepaidEvent(LoanRepaidEvent event) {
+    Account account = event.getAccount();
+
+    // Manager에게 “출금 및 거래기록 생성” 위임
+    accountDomainManager.record(
+        account, event.getAmount(), TransactionType.LOAN_REPAYMENT, false, event.getLoanName());
+  }
+}

--- a/bank/src/main/java/com/fisa/bank/account/application/listener/AccountTransactionListener.java
+++ b/bank/src/main/java/com/fisa/bank/account/application/listener/AccountTransactionListener.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import com.fisa.bank.account.application.service.AccountDomainManager;
 import com.fisa.bank.account.persistence.entity.Account;
 import com.fisa.bank.account.persistence.enums.TransactionType;
+import com.fisa.bank.loan.application.event.LoanCancelledEvent;
 import com.fisa.bank.loan.application.event.LoanRepaidEvent;
 
 @Component
@@ -24,5 +25,13 @@ public class AccountTransactionListener {
     // Manager에게 “출금 및 거래기록 생성” 위임
     accountDomainManager.record(
         account, event.getAmount(), TransactionType.LOAN_REPAYMENT, false, event.getLoanName());
+  }
+
+  @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+  public void handleLoanCancelledEvent(LoanCancelledEvent event) {
+    Account account = event.getAccount();
+    // Manager에게 “중도 상환 출금 및 거래기록 생성” 위임
+    accountDomainManager.record(
+        account, event.getAmount(), TransactionType.EARLY_REPAYMENT, false, event.getLoanName());
   }
 }

--- a/bank/src/main/java/com/fisa/bank/account/application/service/AccountDomainManager.java
+++ b/bank/src/main/java/com/fisa/bank/account/application/service/AccountDomainManager.java
@@ -1,0 +1,54 @@
+package com.fisa.bank.account.application.service;
+
+import lombok.RequiredArgsConstructor;
+
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fisa.bank.account.persistence.entity.Account;
+import com.fisa.bank.account.persistence.entity.AccountTransaction;
+import com.fisa.bank.account.persistence.enums.TransactionType;
+import com.fisa.bank.account.persistence.repository.AccountTransactionRepository;
+
+/*
+    Account 도메인 이외에서는 주입하지 말 것.
+*/
+@Service
+@RequiredArgsConstructor
+public class AccountDomainManager {
+  private final AccountTransactionRepository transactionRepository;
+
+  @Transactional
+  public AccountTransaction record(
+      Account account,
+      BigDecimal amount,
+      TransactionType type,
+      boolean isDeposit,
+      String destination) {
+
+    BigDecimal before = account.getBalance();
+
+    if (isDeposit) {
+      account.deposit(amount);
+    } else {
+      account.withdraw(amount);
+    }
+
+    BigDecimal after = account.getBalance();
+
+    AccountTransaction trx =
+        AccountTransaction.builder()
+            .account(account)
+            .type(type)
+            .amount(amount)
+            .balanceBefore(before)
+            .balanceAfter(after)
+            .isIncome(isDeposit)
+            .destinationAccount(destination)
+            .build();
+
+    return transactionRepository.save(trx);
+  }
+}

--- a/bank/src/main/java/com/fisa/bank/account/application/service/AccountTransactionService.java
+++ b/bank/src/main/java/com/fisa/bank/account/application/service/AccountTransactionService.java
@@ -2,7 +2,6 @@ package com.fisa.bank.account.application.service;
 
 import lombok.RequiredArgsConstructor;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -18,11 +17,9 @@ import com.fisa.bank.account.application.dto.response.AccountTransactionListResp
 import com.fisa.bank.account.application.dto.response.AccountTransactionResponse;
 import com.fisa.bank.account.application.dto.response.CardPaymentResponse;
 import com.fisa.bank.account.application.dto.response.TransferResponse;
-import com.fisa.bank.account.application.exception.InsufficientBalanceException;
 import com.fisa.bank.account.application.exception.InvalidTransferTargetException;
 import com.fisa.bank.account.application.service.reader.AccountReader;
 import com.fisa.bank.account.persistence.entity.Account;
-import com.fisa.bank.account.persistence.entity.AccountTransaction;
 import com.fisa.bank.account.persistence.entity.CardTransaction;
 import com.fisa.bank.account.persistence.enums.TransactionType;
 import com.fisa.bank.account.persistence.repository.AccountTransactionRepository;
@@ -34,114 +31,76 @@ import com.fisa.bank.common.aop.annotation.VerifyOwner;
 @RequiredArgsConstructor
 public class AccountTransactionService {
 
-  private final AccountTransactionRepository accountTransactionRepository;
-  private final CardTransactionRepository cardTransactionRepository;
   private final AccountReader accountReader;
+  private final AccountDomainManager accountDomainManager;
+  private final CardTransactionRepository cardTransactionRepository;
+  private final AccountTransactionRepository accountTransactionRepository;
 
   @Value("${bank.code}")
   private String ourBankCode;
 
-  // 거래 시 거래 전, 거래 후 금액, 잔액 부족 등의 공통의 로직을 작성
-  private AccountTransaction recordTransaction(
-      Account account,
-      BigDecimal amount,
-      TransactionType type,
-      boolean isIncome,
-      String destinationAccount) {
-    BigDecimal before = account.getBalance();
-    BigDecimal after = isIncome ? before.add(amount) : before.subtract(amount);
-
-    // 출금 시 잔액 부족 검증
-    if (!isIncome && before.compareTo(amount) < 0) {
-      throw new InsufficientBalanceException();
-    }
-
-    account.updateBalance(after);
-
-    AccountTransaction trx =
-        AccountTransaction.builder()
-            .account(account)
-            .type(type)
-            .amount(amount)
-            .balanceBefore(before)
-            .balanceAfter(after)
-            .isIncome(isIncome)
-            .destinationAccount(destinationAccount)
-            .build();
-
-    return accountTransactionRepository.save(trx);
-  }
-
-  // 출금
-  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")
   @Transactional
+  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")
   public AccountTransactionResponse withdraw(String accountNumber, AccountWithdrawRequest request) {
     Account account = accountReader.getAccountByAccountNumberWithLock(accountNumber);
-
-    AccountTransaction trx =
-        recordTransaction(account, request.amount(), TransactionType.ATM_WITHDRAW, false, null);
-
+    var trx =
+        accountDomainManager.record(
+            account, request.amount(), TransactionType.ATM_WITHDRAW, false, null);
     return AccountTransactionResponse.from(trx);
   }
 
-  // 입금
-  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")
   @Transactional
+  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")
   public AccountTransactionResponse deposit(String accountNumber, AccountDepositRequest request) {
     Account account = accountReader.getAccountByAccountNumberWithLock(accountNumber);
-
-    AccountTransaction trx =
-        recordTransaction(account, request.amount(), TransactionType.ATM_DEPOSIT, true, null);
-
+    var trx =
+        accountDomainManager.record(
+            account, request.amount(), TransactionType.ATM_DEPOSIT, true, null);
     return AccountTransactionResponse.from(trx);
   }
 
-  // 송금
-  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "fromAccountNumber")
   @Transactional
+  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "fromAccountNumber")
   public TransferResponse transfer(TransferRequest request) {
-    String fromNo = request.fromAccountNumber();
-    String toNo = request.toAccountNumber();
-    BigDecimal amount = request.amount();
-
-    if (ourBankCode.equals(request.toBankCode()) && fromNo.equals(toNo)) {
+    if (ourBankCode.equals(request.toBankCode())
+        && request.fromAccountNumber().equals(request.toAccountNumber())) {
       throw new InvalidTransferTargetException();
     }
 
     if (ourBankCode.equals(request.toBankCode())) {
-      var pair = accountReader.lockTransferAccounts(fromNo, toNo);
-      Account from = pair.from();
-      Account to = pair.to();
+      var pair =
+          accountReader.lockTransferAccounts(
+              request.fromAccountNumber(), request.toAccountNumber());
+      var from = pair.from();
+      var to = pair.to();
 
-      recordTransaction(from, amount, TransactionType.TRANSFER_SEND, false, to.getAccountNumber());
-      recordTransaction(
-          to, amount, TransactionType.TRANSFER_RECEIVE, true, from.getAccountNumber());
+      accountDomainManager.record(
+          from, request.amount(), TransactionType.TRANSFER_SEND, false, to.getAccountNumber());
+      accountDomainManager.record(
+          to, request.amount(), TransactionType.TRANSFER_RECEIVE, true, from.getAccountNumber());
 
-      return TransferResponse.of(from, to, amount);
+      return TransferResponse.of(from, to, request.amount());
     } else {
-      Account from = accountReader.getAccountByAccountNumberWithLock(fromNo);
-      recordTransaction(from, amount, TransactionType.EXTERNAL_TRANSFER_SEND, false, toNo);
-      return TransferResponse.ofExternal(from, toNo, amount);
+      var from = accountReader.getAccountByAccountNumberWithLock(request.fromAccountNumber());
+      accountDomainManager.record(
+          from,
+          request.amount(),
+          TransactionType.EXTERNAL_TRANSFER_SEND,
+          false,
+          request.toAccountNumber());
+      return TransferResponse.ofExternal(from, request.toAccountNumber(), request.amount());
     }
   }
 
-  // 카드 결제
-  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")
   @Transactional
+  @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")
   public CardPaymentResponse payByCard(String accountNumber, CardPaymentRequest request) {
-    Account account = accountReader.getAccountByAccountNumberWithLock(accountNumber);
+    var account = accountReader.getAccountByAccountNumberWithLock(accountNumber);
 
-    // 계좌에도 로그 남기기위해 반영
-    recordTransaction(
-        account,
-        request.amount(),
-        TransactionType.CARD_PAYMENT,
-        false,
-        request.storeName() // destinationAccount 대신 storeName 기록
-        );
+    accountDomainManager.record(
+        account, request.amount(), TransactionType.CARD_PAYMENT, false, request.storeName());
 
-    // 💾 카드 결제 내역 추가 저장
-    CardTransaction cardTrx =
+    var cardTrx =
         CardTransaction.builder()
             .account(account)
             .amount(request.amount())
@@ -149,9 +108,7 @@ public class AccountTransactionService {
             .category(request.category())
             .build();
 
-    CardTransaction saved = cardTransactionRepository.save(cardTrx);
-
-    return CardPaymentResponse.from(saved);
+    return CardPaymentResponse.from(cardTransactionRepository.save(cardTrx));
   }
 
   @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")

--- a/bank/src/main/java/com/fisa/bank/account/application/service/AccountTransactionService.java
+++ b/bank/src/main/java/com/fisa/bank/account/application/service/AccountTransactionService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -67,7 +66,6 @@ public class AccountTransactionService {
             .balanceBefore(before)
             .balanceAfter(after)
             .isIncome(isIncome)
-            .date(LocalDateTime.now())
             .destinationAccount(destinationAccount)
             .build();
 
@@ -164,13 +162,14 @@ public class AccountTransactionService {
     // 거래내역 조회
     List<AccountTransactionResponse> transactions =
         accountTransactionRepository
-            .findByAccountAndDateGreaterThanEqualAndDateBefore(
+            .findByAccountAndCreatedAtGreaterThanEqualAndCreatedAtBefore(
                 account, startDate.atStartOfDay(), endDate.plusDays(1).atStartOfDay())
             .stream()
             .map(AccountTransactionResponse::from)
             .toList();
 
     // 응답 DTO 생성
-    return new AccountTransactionListResponse(account.getAccountNumber(), transactions);
+    return new AccountTransactionListResponse(
+        account.getAccountId().getValue(), account.getAccountNumber(), transactions);
   }
 }

--- a/bank/src/main/java/com/fisa/bank/account/persistence/entity/Account.java
+++ b/bank/src/main/java/com/fisa/bank/account/persistence/entity/Account.java
@@ -19,6 +19,7 @@ import org.hibernate.annotations.JavaType;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import com.fisa.bank.account.application.exception.InsufficientBalanceException;
 import com.fisa.bank.account.persistence.entity.id.*;
 import com.fisa.bank.common.persistence.entity.BaseEntity;
 import com.fisa.bank.loan.persistence.entity.LoanLedger;
@@ -62,8 +63,14 @@ public class Account extends BaseEntity {
         .build();
   }
 
-  // 거래 후 잔액으로 balance 변경
-  public void updateBalance(BigDecimal after) {
-    this.balance = after;
+  public void withdraw(BigDecimal amount) {
+    if (balance.compareTo(amount) < 0) {
+      throw new InsufficientBalanceException();
+    }
+    this.balance = balance.subtract(amount);
+  }
+
+  public void deposit(BigDecimal amount) {
+    this.balance = balance.add(amount);
   }
 }

--- a/bank/src/main/java/com/fisa/bank/account/persistence/entity/AccountTransaction.java
+++ b/bank/src/main/java/com/fisa/bank/account/persistence/entity/AccountTransaction.java
@@ -14,7 +14,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 
 import org.hibernate.annotations.JavaType;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -55,9 +54,6 @@ public class AccountTransaction extends BaseEntity {
 
   @Column(name = "balance_after", nullable = false)
   private BigDecimal balanceAfter; // 거래 후 잔액
-
-  @Column(name = "date", nullable = false)
-  private LocalDateTime date;
 
   @Column(name = "destination_account", length = 20)
   private String destinationAccount;

--- a/bank/src/main/java/com/fisa/bank/account/persistence/enums/TransactionType.java
+++ b/bank/src/main/java/com/fisa/bank/account/persistence/enums/TransactionType.java
@@ -7,5 +7,7 @@ public enum TransactionType {
   TRANSFER_RECEIVE, // 송금 (받는 쪽)
   EXTERNAL_TRANSFER_SEND, // 타행 송금 (보내는 쪽)
   CARD_PAYMENT, // 카드 결제
-  CARD_REFUND // 카드 환불
+  CARD_REFUND, // 카드 환불
+  LOAN_REPAYMENT, // 대출 상환
+  EARLY_REPAYMENT // 중도 상환
 }

--- a/bank/src/main/java/com/fisa/bank/account/persistence/repository/AccountTransactionRepository.java
+++ b/bank/src/main/java/com/fisa/bank/account/persistence/repository/AccountTransactionRepository.java
@@ -12,6 +12,6 @@ import com.fisa.bank.account.persistence.entity.id.AccountTransactionId;
 public interface AccountTransactionRepository
     extends JpaRepository<AccountTransaction, AccountTransactionId> {
 
-  List<AccountTransaction> findByAccountAndDateGreaterThanEqualAndDateBefore(
+  List<AccountTransaction> findByAccountAndCreatedAtGreaterThanEqualAndCreatedAtBefore(
       Account account, LocalDateTime start, LocalDateTime end);
 }

--- a/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestUserDetailsService.java
+++ b/bank/src/main/java/com/fisa/bank/common/config/security/mock/TestUserDetailsService.java
@@ -6,7 +6,6 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.stereotype.Component;
 
 /** 테스트용 UserDetailsService */
 public class TestUserDetailsService implements UserDetailsService {

--- a/bank/src/main/java/com/fisa/bank/loan/application/event/LoanCancelledEvent.java
+++ b/bank/src/main/java/com/fisa/bank/loan/application/event/LoanCancelledEvent.java
@@ -1,0 +1,16 @@
+package com.fisa.bank.loan.application.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+import com.fisa.bank.account.persistence.entity.Account;
+
+@Getter
+@AllArgsConstructor
+public class LoanCancelledEvent {
+  private final Account account;
+  private final BigDecimal amount;
+  private final String loanName;
+}

--- a/bank/src/main/java/com/fisa/bank/loan/application/event/LoanRepaidEvent.java
+++ b/bank/src/main/java/com/fisa/bank/loan/application/event/LoanRepaidEvent.java
@@ -1,0 +1,16 @@
+package com.fisa.bank.loan.application.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+import com.fisa.bank.account.persistence.entity.Account;
+
+@Getter
+@AllArgsConstructor
+public class LoanRepaidEvent {
+  private final Account account;
+  private final BigDecimal amount;
+  private final String loanName;
+}

--- a/bank/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/bank/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,7 @@ import com.fisa.bank.loan.application.dto.response.LoanProductCreateResponse;
 import com.fisa.bank.loan.application.dto.response.LoanProductResponse;
 import com.fisa.bank.loan.application.dto.response.LoanTransactionResponse;
 import com.fisa.bank.loan.application.dto.response.PagedResponse;
+import com.fisa.bank.loan.application.event.LoanRepaidEvent;
 import com.fisa.bank.loan.application.exception.*;
 import com.fisa.bank.loan.application.model.EarlyRepayment;
 import com.fisa.bank.loan.application.model.MonthlyRepayment;
@@ -63,6 +65,7 @@ public class LoanService {
   private final CalculatorService calculatorService;
   private final LoanReader loanReader;
   private final RequesterInfo requesterInfo;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional
   public LoanProductCreateResponse createLoanProduct(LoanProductCreateRequest requestDTO) {
@@ -224,10 +227,6 @@ public class LoanService {
       throw new InsufficientBalanceAmountException();
     }
 
-    BigDecimal afterBalance = account.getBalance().subtract(monthlyRepayment.getMonthlyPayment());
-
-    account.updateBalance(afterBalance); // 잔액 변경
-
     // 상환 가능하다면, 원장 테이블 업데이트 후 이력성 테이블에 데이터 저장
     // 남은 원금, 다음 상환일, 마지막 상환 날짜 업데이트
     LocalDateTime lastRepaymentDate = loanLedger.getNextRepaymentDate();
@@ -251,6 +250,10 @@ public class LoanService {
 
     loanTransactionRepository.save(loanTransaction);
 
+    eventPublisher.publishEvent(
+        new LoanRepaidEvent(
+            account, monthlyRepayment.getMonthlyPayment(), loanLedger.getLoanProduct().getName()));
+
     return LoanTransactionResponse.from(loanTransaction);
   }
 
@@ -273,8 +276,6 @@ public class LoanService {
       throw new InsufficientBalanceAmountException();
     }
 
-    BigDecimal afterBalance = account.getBalance().subtract(earlyRepayment.getMustPaidAmount());
-
     loanLedger.updateLoanLedger(
         UpdateLoanLedgerParam.builder()
             .remainPrincipal(BigDecimal.ZERO)
@@ -283,14 +284,16 @@ public class LoanService {
             .status(RepaymentStatus.TERMINATED)
             .build());
 
-    account.updateBalance(afterBalance); // 잔액 변경
-
     LoanTransaction loanTransaction =
         LoanTransactionFactory.createEarlyRepay(loanLedger, earlyRepayment, today);
 
     loanLedger.addLoanTransactionList(loanTransaction);
 
     loanTransactionRepository.save(loanTransaction);
+
+    eventPublisher.publishEvent(
+        new LoanRepaidEvent(
+            account, earlyRepayment.getMustPaidAmount(), loanLedger.getLoanProduct().getName()));
   }
 
   @Transactional(readOnly = true)

--- a/bank/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
+++ b/bank/src/main/java/com/fisa/bank/loan/application/service/LoanService.java
@@ -30,6 +30,7 @@ import com.fisa.bank.loan.application.dto.response.LoanProductCreateResponse;
 import com.fisa.bank.loan.application.dto.response.LoanProductResponse;
 import com.fisa.bank.loan.application.dto.response.LoanTransactionResponse;
 import com.fisa.bank.loan.application.dto.response.PagedResponse;
+import com.fisa.bank.loan.application.event.LoanCancelledEvent;
 import com.fisa.bank.loan.application.event.LoanRepaidEvent;
 import com.fisa.bank.loan.application.exception.*;
 import com.fisa.bank.loan.application.model.EarlyRepayment;
@@ -292,7 +293,7 @@ public class LoanService {
     loanTransactionRepository.save(loanTransaction);
 
     eventPublisher.publishEvent(
-        new LoanRepaidEvent(
+        new LoanCancelledEvent(
             account, earlyRepayment.getMustPaidAmount(), loanLedger.getLoanProduct().getName()));
   }
 

--- a/bank/src/test/java/com/fisa/bank/account/application/service/AccountServiceTest.java
+++ b/bank/src/test/java/com/fisa/bank/account/application/service/AccountServiceTest.java
@@ -146,7 +146,7 @@ class AccountServiceTest {
     String accountNumber = "1234567890";
     Long userId = 1L;
     Account accountWithBalance = Account.create("1234567890", testUser, "088");
-    accountWithBalance.updateBalance(new BigDecimal("10000"));
+    accountWithBalance.deposit(new BigDecimal("10000"));
 
     when(accountReader.getAccountByAccountNumber(accountNumber)).thenReturn(accountWithBalance);
 

--- a/bank/src/test/java/com/fisa/bank/account/application/service/AccountTransactionConcurrencyTest.java
+++ b/bank/src/test/java/com/fisa/bank/account/application/service/AccountTransactionConcurrencyTest.java
@@ -63,10 +63,10 @@ class AccountTransactionConcurrencyTest {
     testUser = userRepository.saveAndFlush(testUser);
 
     account1 = Account.create("1234567890", testUser, "088");
-    account1.updateBalance(new BigDecimal("1000000"));
+    account1.deposit(new BigDecimal("1000000"));
 
     account2 = Account.create("9876543210", testUser, "088");
-    account2.updateBalance(new BigDecimal("1000000"));
+    account2.deposit(new BigDecimal("1000000"));
 
     accountRepository.saveAndFlush(account1);
     accountRepository.saveAndFlush(account2);
@@ -236,7 +236,7 @@ class AccountTransactionConcurrencyTest {
   @DisplayName("잔액 부족 시 동시 출금이 올바르게 제어된다")
   void concurrentWithdrawalsWithInsufficientBalance() throws InterruptedException {
     Account poorAccount = Account.create("1111111111", testUser, "088");
-    poorAccount.updateBalance(new BigDecimal("50000"));
+    poorAccount.deposit(new BigDecimal("50000"));
     accountRepository.save(poorAccount);
 
     int threadCount = 10;

--- a/bank/src/test/java/com/fisa/bank/account/persistence/entity/AccountTest.java
+++ b/bank/src/test/java/com/fisa/bank/account/persistence/entity/AccountTest.java
@@ -37,17 +37,32 @@ class AccountTest {
   }
 
   @Test
-  @DisplayName("잔액 업데이트가 정상적으로 수행된다")
-  void updateBalance() {
+  @DisplayName("입금이 정상적으로 수행된다")
+  void deposit() {
     // given
     Account account = Account.create("1234567890", createTestUser(), "088");
-    BigDecimal newBalance = new BigDecimal("10000");
+    BigDecimal depositAmount = new BigDecimal("10000");
 
     // when
-    account.updateBalance(newBalance);
+    account.deposit(depositAmount);
 
     // then
-    assertThat(account.getBalance()).isEqualByComparingTo(newBalance);
+    assertThat(account.getBalance()).isEqualByComparingTo(depositAmount);
+  }
+
+  @Test
+  @DisplayName("출금이 정상적으로 수행된다")
+  void withdraw() {
+    // given
+    Account account = Account.create("1234567890", createTestUser(), "088");
+    account.deposit(new BigDecimal("10000"));
+    BigDecimal withdrawAmount = new BigDecimal("5000");
+
+    // when
+    account.withdraw(withdrawAmount);
+
+    // then
+    assertThat(account.getBalance()).isEqualByComparingTo(new BigDecimal("5000"));
   }
 
   @Test

--- a/bank/src/test/java/com/fisa/bank/account/persistence/entity/AccountTransactionTest.java
+++ b/bank/src/test/java/com/fisa/bank/account/persistence/entity/AccountTransactionTest.java
@@ -37,7 +37,6 @@ class AccountTransactionTest {
             .amount(amount)
             .balanceBefore(balanceBefore)
             .balanceAfter(balanceAfter)
-            .date(transactionDate)
             .isIncome(true)
             .build();
 
@@ -69,7 +68,6 @@ class AccountTransactionTest {
             .amount(amount)
             .balanceBefore(balanceBefore)
             .balanceAfter(balanceAfter)
-            .date(transactionDate)
             .isIncome(false)
             .build();
 
@@ -102,7 +100,6 @@ class AccountTransactionTest {
             .amount(amount)
             .balanceBefore(balanceBefore)
             .balanceAfter(balanceAfter)
-            .date(transactionDate)
             .destinationAccount(destinationAccount)
             .isIncome(false)
             .build();
@@ -136,7 +133,6 @@ class AccountTransactionTest {
             .amount(amount)
             .balanceBefore(balanceBefore)
             .balanceAfter(balanceAfter)
-            .date(transactionDate)
             .destinationAccount(sourceAccount)
             .isIncome(true)
             .build();
@@ -170,7 +166,6 @@ class AccountTransactionTest {
             .amount(amount)
             .balanceBefore(balanceBefore)
             .balanceAfter(balanceAfter)
-            .date(transactionDate)
             .destinationAccount(storeName)
             .isIncome(false)
             .build();
@@ -202,7 +197,6 @@ class AccountTransactionTest {
             .amount(amount)
             .balanceBefore(balanceBefore)
             .balanceAfter(balanceAfter)
-            .date(LocalDateTime.now())
             .isIncome(false)
             .build();
 
@@ -232,7 +226,6 @@ class AccountTransactionTest {
             .amount(amount)
             .balanceBefore(balanceBefore)
             .balanceAfter(balanceAfter)
-            .date(transactionDate)
             .destinationAccount(externalAccount)
             .isIncome(false)
             .build();
@@ -258,12 +251,12 @@ class AccountTransactionTest {
             .amount(new BigDecimal("10000"))
             .balanceBefore(BigDecimal.ZERO)
             .balanceAfter(new BigDecimal("10000"))
-            .date(specificDate)
             .isIncome(true)
             .build();
 
     // then
-    assertThat(transaction.getDate()).isEqualTo(specificDate);
+    assertThat(transaction.getCreatedAt()).isNotNull();
+    assertThat(transaction.getCreatedAt()).isBeforeOrEqualTo(LocalDateTime.now());
   }
 
   private Account createTestAccount() {

--- a/bank/src/test/java/com/fisa/bank/account/persistence/entity/AccountTransactionTest.java
+++ b/bank/src/test/java/com/fisa/bank/account/persistence/entity/AccountTransactionTest.java
@@ -265,7 +265,7 @@ class AccountTransactionTest {
 
   private Account createTestAccountWithBalance(BigDecimal balance) {
     Account account = Account.create("1234567890", createTestUser(), "088");
-    account.updateBalance(balance);
+    account.deposit(balance);
     return account;
   }
 


### PR DESCRIPTION
## 관련 이슈
- #79 

## 기능 
- 계좌 아이디 값 반환으로 수정 
- 대출 상환 시 계좌 거래 내역에도 반영 되게 수정

## 리팩토링
- 기존 LoanService에서 account 의 update 함수를 이용하여 잔액을 업데이트 하였음. 
>도메인 간 분리를 위해, update 함수를 삭제하고 withdraw와 deposit 함수를 추가하였으며 account가 아닌 다른 도메인에서 계좌를 수정해야 할 때는 이벤트를 발행하도록 수정하였음 