### PR TITLE
[FIX] Account 자동 생성 오류 수정

### DIFF
--- a/bank/src/main/java/com/fisa/bank/domains/account/application/listener/UserCreatedEventListener.java
+++ b/bank/src/main/java/com/fisa/bank/domains/account/application/listener/UserCreatedEventListener.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -20,6 +22,12 @@ public class UserCreatedEventListener {
   @TransactionalEventListener(
       classes = UserCreatedEvent.class,
       phase = TransactionPhase.AFTER_COMMIT)
+  // 상위 트랜잭션이 종료되어도, 무조건 새로운 트랜잭션을 연다.
+  // 상위 트랜잭션은 이미 COMMIT 된 상태여서, 자원을 정리하고 있다.
+  // accountService.createIncomeAccount() 메소드는 @Transactional 어노테이션으로
+  // 기존에 상위 트랜잭션이 존재하면 해당 트랜잭션에 참여하려고 한다. 하지만 이미 커밋이 된 상태이고, 트랜잭션 매니저가 자원을 정리 중이므로
+  // 제대로된 트랜잭션을 사용할 수 없다. 따라서 Propagation.REQUIRES_NEW 를 사용해서 무조건 새로운 트랜잭션을 열도록 한다.
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void createIncomeAccount(UserCreatedEvent event) {
     // TODO: 재시도 로직 추가
     String accountNumber = accountService.createIncomeAccount(event.getUserId()).accountNumber();

--- a/bank/src/main/java/com/fisa/bank/domains/account/persistence/entity/Account.java
+++ b/bank/src/main/java/com/fisa/bank/domains/account/persistence/entity/Account.java
@@ -83,6 +83,10 @@ public class Account extends BaseEntity {
   @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<CardTransaction> cardTransactions = new ArrayList<>();
 
+  public static Account create(String accountNumber, User user, String bankCode) {
+    return create(accountNumber, user, bankCode, false);
+  }
+
   public static Account create(String accountNumber, User user, String bankCode, boolean isIncome) {
     return Account.builder()
         .accountNumber(accountNumber)

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/dto/request/LoanApplyForRequest.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/dto/request/LoanApplyForRequest.java
@@ -1,6 +1,7 @@
 package com.fisa.bank.domains.loan.application.dto.request;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -29,6 +30,7 @@ public class LoanApplyForRequest {
   @Min(value = 1, message = "상환 기간은 최소 1년 이상이어야 합니다.")
   private Integer term;
 
+  @NotBlank(message = "계좌 번호를 입력해주세요.")
   private String accountNumber;
 
   @NotNull(message = "자동 예치 여부를 입력해주세요.")

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
@@ -128,11 +128,6 @@ public class LoanService {
     // 유저 정보 추출
     User user = userReader.getUserById(userId.getValue());
     String accountNumber = request.getAccountNumber();
-
-    // 계좌 새로 생성
-    if (!StringUtils.hasText(accountNumber))
-      accountNumber = accountService.createAccount(userId.getValue()).accountNumber();
-
     Account account = accountReader.getAccountByAccountNumber(accountNumber);
 
     // 급여 계좌로는 대출 가입 불가

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
@@ -11,7 +11,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 import com.fisa.bank.domains.account.application.exception.InsufficientBalanceException;
 import com.fisa.bank.domains.account.application.service.AccountService;


### PR DESCRIPTION
## 상황
- 신규 사용자 회원 가입할 경우, 이벤트 핸들러를 통해서 `소득 전용 계좌`를 생성합니다. 하지만 이벤트 핸들러가 새로운 계좌를 생성하는 경우, `repository.save()`를 호출하더라도, `id`가 생성되지 않은 엔티티가 반환되지 않는 문제가 발생했습니다.

## 원인
- `@TransactionalEventListener` 를 사용했으며, 이 이벤트 리스너의 동작은 상위 트랜잭션이 커밋되면, 같은 스레드 내에서 이벤트 핸들로 직을 수행합니다. 이벤트 핸들 내부 로직은 새로운 데이터를 생성하는 로직이며, `AccountService`를 호출합니다.
- 이미 `AccountService` 의 `createIncomAccount` 는 트랜잭션 어노테이션이 붙어 있고, 같은 스레드에 바인딩 된 `Transaction`객체를 재사용합니다.
- 하지만 이미 트랜잭션이 끝난 이후였기 때문에 새로운 트랜잭션을 활용하지 못하는 상태입니다. 그렇기 때문에 `repository.save()`를 호출해도 트랜잭션을 제대로 사용하지 못하는 상황이므로, insert 쿼리가 날아가지 않아 `entity`의 `id` 필드가 null로 유지됩니다.

## 해결
- `UserCreatedEventListener`에 `@Transactional(propagation = Propagation.REQUIRES_NEW` 를 사용하여, 이 메소드가 호출될 때 언제든지 새로운 트랜잭션을 열도록 합니다.
  - 해당 옵션은 내부적으로 `TransactionSynchronizationManager (트랜잭션 동기화 매니저)` 가 기존의 스레드 로컬에 바인딩 된 트랜잭션을 잠시 떼어내고, 새로운 트랜잭션을 스레드 로컬에 바인딩 합니다.
  - 이렇게 함으로써 AccountService 는 내부적으로 새로운 트랜잭션을 사용하여 정상적으로 `entity` 의 `id` 필드에 새로운 id 값이 담깁니다.