### PR TITLE
[FEAT] 선납 관련 정보 조회 기능 추가

### DIFF
--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/dto/response/InterestDetailResponse.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/dto/response/InterestDetailResponse.java
@@ -1,0 +1,14 @@
+package com.fisa.bank.domains.loan.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class InterestDetailResponse {
+  private final LocalDateTime repaymentDate;
+  private final BigDecimal interest;
+}

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/dto/response/PrepaymentInfoResponse.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/dto/response/PrepaymentInfoResponse.java
@@ -10,5 +10,5 @@ import java.util.List;
 @Getter
 public class PrepaymentInfoResponse {
   private final BigDecimal earlyRepayment;
-  private final List<InterestDetailResponse> interestDetailResponse;
+  private final List<InterestDetailResponse> interestDetailResponses;
 }

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/dto/response/PrepaymentInfoResponse.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/dto/response/PrepaymentInfoResponse.java
@@ -1,0 +1,14 @@
+package com.fisa.bank.domains.loan.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Builder
+@Getter
+public class PrepaymentInfoResponse {
+  private final BigDecimal earlyRepayment;
+  private final List<InterestDetailResponse> interestDetailResponse;
+}

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/model/MonthlyRepayment.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/model/MonthlyRepayment.java
@@ -3,6 +3,7 @@ package com.fisa.bank.domains.loan.application.model;
 import lombok.Getter;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Getter
 public class MonthlyRepayment {
@@ -12,19 +13,22 @@ public class MonthlyRepayment {
   private BigDecimal interestPayment;
   private BigDecimal monthlyPayment;
   private BigDecimal remainPrincipal;
+  private LocalDateTime repaymentDate;
 
   public MonthlyRepayment(
       int term,
       BigDecimal principalPayment,
       BigDecimal interestPayment,
       BigDecimal monthlyPayment,
-      BigDecimal remainPrincipal) {
+      BigDecimal remainPrincipal,
+      LocalDateTime repaymentDate) {
     this.term = term;
     //        this.remainingTerm = term;
     this.principalPayment = principalPayment;
     this.interestPayment = interestPayment;
     this.monthlyPayment = monthlyPayment;
     this.remainPrincipal = remainPrincipal;
+    this.repaymentDate = repaymentDate;
   }
 
   public MonthlyRepayment() {}

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
@@ -367,31 +367,30 @@ public class LoanService {
     loanLedger.updateAutoDeposit(autoDepositEnabled);
   }
 
-  @Transactional
+  @Transactional(readOnly = true)
   public List<PrepaymentInfoResponse> getPrepaymentInfos() {
-    // TODO: 유저 모든 대출 조회
+    // 유저 모든 대출 조회
     Long userId = requesterInfo.getUserId().getValue();
     List<LoanLedger> loanLedgers = loanReader.findAllByUserId(userId);
 
     // 대출 별 선납 정보를 담을 리스트
     List<PrepaymentInfoResponse> prepaymentInfoResponses = new ArrayList<>();
-
+    LocalDateTime now = LocalDateTime.now();
     for (LoanLedger loanLedger : loanLedgers) {
       if (EXCLUDED_REPAYMENT_STATUSES.contains(loanLedger.getRepaymentStatus())) continue;
-      // TODO: 각 대출 별 중도 상환 수수료 계산
+      // 각 대출 별 중도 상환 수수료 계산
       BigDecimal earlyPaidRate = loanLedger.getEarlyRepayInterestRate();
       // 중도 상환 금액 계산
-      EarlyRepayment earlyRepayment =
-          EarlyRepayment.create(loanLedger, LocalDateTime.now(), earlyPaidRate);
+      EarlyRepayment earlyRepayment = EarlyRepayment.create(loanLedger, now, earlyPaidRate);
 
-      // TODO: 각 대출 별 남은 기간의 이자 리스트
+      // 각 대출 별 남은 기간의 이자 리스트
       List<InterestDetailResponse> interestDetailResponses =
           calculatorService.calculateRemainingInterests(loanLedger);
 
       PrepaymentInfoResponse prepaymentInfoResponse =
           PrepaymentInfoResponse.builder()
               .earlyRepayment(earlyRepayment.getEarlyPaidCost())
-              .interestDetailResponse(interestDetailResponses)
+              .interestDetailResponses(interestDetailResponses)
               .build();
 
       prepaymentInfoResponses.add(prepaymentInfoResponse);

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -25,13 +26,7 @@ import com.fisa.bank.domains.interest.persistence.entity.InterestRate;
 import com.fisa.bank.domains.loan.application.dto.request.LoanApplyForRequest;
 import com.fisa.bank.domains.loan.application.dto.request.LoanMonthlyRepayRequest;
 import com.fisa.bank.domains.loan.application.dto.request.LoanProductCreateRequest;
-import com.fisa.bank.domains.loan.application.dto.response.LoanApplyforResponse;
-import com.fisa.bank.domains.loan.application.dto.response.LoanLedgerDetailResponse;
-import com.fisa.bank.domains.loan.application.dto.response.LoanLedgerResponse;
-import com.fisa.bank.domains.loan.application.dto.response.LoanProductCreateResponse;
-import com.fisa.bank.domains.loan.application.dto.response.LoanProductResponse;
-import com.fisa.bank.domains.loan.application.dto.response.LoanTransactionResponse;
-import com.fisa.bank.domains.loan.application.dto.response.PagedResponse;
+import com.fisa.bank.domains.loan.application.dto.response.*;
 import com.fisa.bank.domains.loan.application.event.LoanCancelledEvent;
 import com.fisa.bank.domains.loan.application.event.LoanRepaidEvent;
 import com.fisa.bank.domains.loan.application.exception.DuplicateLoanException;
@@ -81,6 +76,8 @@ public class LoanService {
   private final RequesterInfo requesterInfo;
   private final ApplicationEventPublisher eventPublisher;
   private final AccountService accountService;
+  private static final List<RepaymentStatus> EXCLUDED_REPAYMENT_STATUSES =
+      List.of(RepaymentStatus.COMPLETED, RepaymentStatus.TERMINATED);
 
   @Transactional
   public LoanProductCreateResponse createLoanProduct(LoanProductCreateRequest requestDTO) {
@@ -368,5 +365,37 @@ public class LoanService {
     LoanLedger loanLedger = loanReader.findLoanLedgerById(loanLedgerId);
 
     loanLedger.updateAutoDeposit(autoDepositEnabled);
+  }
+
+  @Transactional
+  public List<PrepaymentInfoResponse> getPrepaymentInfos() {
+    // TODO: 유저 모든 대출 조회
+    Long userId = requesterInfo.getUserId().getValue();
+    List<LoanLedger> loanLedgers = loanReader.findAllByUserId(userId);
+
+    // 대출 별 선납 정보를 담을 리스트
+    List<PrepaymentInfoResponse> prepaymentInfoResponses = new ArrayList<>();
+
+    for (LoanLedger loanLedger : loanLedgers) {
+      if (EXCLUDED_REPAYMENT_STATUSES.contains(loanLedger.getRepaymentStatus())) continue;
+      // TODO: 각 대출 별 중도 상환 수수료 계산
+      BigDecimal earlyPaidRate = loanLedger.getEarlyRepayInterestRate();
+      // 중도 상환 금액 계산
+      EarlyRepayment earlyRepayment =
+          EarlyRepayment.create(loanLedger, LocalDateTime.now(), earlyPaidRate);
+
+      // TODO: 각 대출 별 남은 기간의 이자 리스트
+      List<InterestDetailResponse> interestDetailResponses =
+          calculatorService.calculateRemainingInterests(loanLedger);
+
+      PrepaymentInfoResponse prepaymentInfoResponse =
+          PrepaymentInfoResponse.builder()
+              .earlyRepayment(earlyRepayment.getEarlyPaidCost())
+              .interestDetailResponse(interestDetailResponses)
+              .build();
+
+      prepaymentInfoResponses.add(prepaymentInfoResponse);
+    }
+    return prepaymentInfoResponses;
   }
 }

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/calculator/BulletCalculator.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/calculator/BulletCalculator.java
@@ -57,6 +57,7 @@ public class BulletCalculator implements LoanCalculator {
         principalPayment.setScale(0, RoundingMode.DOWN),
         interestPayment.setScale(0, RoundingMode.DOWN),
         monthlyPayment.setScale(0, RoundingMode.DOWN),
-        remainPrincipal.subtract(principalPayment));
+        remainPrincipal.subtract(principalPayment),
+        nextRepaymentDate);
   }
 }

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/calculator/CalculatorService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/calculator/CalculatorService.java
@@ -2,11 +2,17 @@ package com.fisa.bank.domains.loan.application.service.calculator;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 
+import com.fisa.bank.domains.loan.application.dto.response.InterestDetailResponse;
 import com.fisa.bank.domains.loan.application.exception.UnknownCalculatorException;
 import com.fisa.bank.domains.loan.application.model.MonthlyRepayment;
 import com.fisa.bank.domains.loan.persistence.entity.LoanLedger;
@@ -37,5 +43,72 @@ public class CalculatorService {
         1, // currentTerm은 실제로 사용되지 않음
         loanLedger.getNextRepaymentDate(),
         loanLedger.getLoanEndDate());
+  }
+
+  /**
+   * [추가된 메서드] LoanLedger를 기반으로 만기일까지의 전체 상환 스케줄을 계산합니다. 이 메서드가 RepaymentType에 맞는 calculate 로직을
+   * 반복적으로 활용합니다.
+   */
+  private List<MonthlyRepayment> calculateFullSchedule(LoanLedger loanLedger) {
+
+    LoanCalculator calculator = calculators.get(loanLedger.getRepaymentType());
+    if (calculator == null) {
+      throw new UnknownCalculatorException();
+    }
+
+    List<MonthlyRepayment> fullSchedule = new ArrayList<>();
+
+    // 시뮬레이션을 위한 가상 변수 설정
+    // 고정값
+    LocalDateTime createdAt = loanLedger.getCreatedAt();
+    LocalDateTime loanEndDate = loanLedger.getLoanEndDate();
+    int termInMonth =
+        (int)
+            ChronoUnit.MONTHS.between(
+                createdAt.toLocalDate().withDayOfMonth(1),
+                loanEndDate.toLocalDate().withDayOfMonth(1));
+    BigDecimal principal = loanLedger.getPrincipal();
+    BigDecimal annualInterestRate =
+        loanLedger.getCompletedInterest().divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP);
+
+    // 반복 갱신할 값
+    BigDecimal remainPrincipal = loanLedger.getRemainPrincipal();
+    LocalDateTime createdAtForLoop = createdAt.plusMonths(1);
+
+    for (int i = 0; i < termInMonth; i++) {
+      MonthlyRepayment repayment =
+          calculator.calculate(
+              principal,
+              remainPrincipal,
+              annualInterestRate,
+              termInMonth,
+              i,
+              createdAtForLoop,
+              loanEndDate);
+      fullSchedule.add(repayment);
+
+      // 남은 원금 갱신
+      remainPrincipal = remainPrincipal.subtract(repayment.getPrincipalPayment());
+
+      // 다음 상환일 1개월 후로 갱신
+      createdAtForLoop = createdAtForLoop.plusMonths(1);
+    }
+
+    return fullSchedule;
+  }
+
+  public List<InterestDetailResponse> calculateRemainingInterests(LoanLedger loanLedger) {
+    List<MonthlyRepayment> fullSchedule = calculateFullSchedule(loanLedger);
+    LocalDateTime nextRepaymentDate = loanLedger.getNextRepaymentDate();
+
+    return fullSchedule.stream()
+        .filter(detail -> !detail.getRepaymentDate().isBefore(nextRepaymentDate))
+        .map(
+            detail ->
+                InterestDetailResponse.builder()
+                    .interest(detail.getInterestPayment())
+                    .repaymentDate(detail.getRepaymentDate())
+                    .build())
+        .collect(Collectors.toList());
   }
 }

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/calculator/CalculatorService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/calculator/CalculatorService.java
@@ -38,7 +38,7 @@ public class CalculatorService {
     return calculator.calculate(
         loanLedger.getPrincipal(),
         loanLedger.getRemainPrincipal(),
-        loanLedger.getCompletedInterest().divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP),
+        loanLedger.getCompletedInterest().divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP),
         loanLedger.getTerm() * 12, // 연 -> 개월로 변경
         1, // currentTerm은 실제로 사용되지 않음
         loanLedger.getNextRepaymentDate(),

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/calculator/EqualInstallmentCalculator.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/calculator/EqualInstallmentCalculator.java
@@ -59,7 +59,8 @@ public class EqualInstallmentCalculator implements LoanCalculator {
         principalPayment,
         interestPayment,
         monthlyPayment,
-        remainPrincipal.subtract(principalPayment));
+        remainPrincipal.subtract(principalPayment),
+        nextRepaymentDate);
   }
 
   // 이전 코드

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/calculator/EqualPrincipalCalculator.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/calculator/EqualPrincipalCalculator.java
@@ -64,7 +64,8 @@ public class EqualPrincipalCalculator implements LoanCalculator {
         principalPayment,
         interestPayment,
         monthlyPayment,
-        remainPrincipal.subtract(principalPayment));
+        remainPrincipal.subtract(principalPayment),
+        nextRepaymentDate);
   }
 
   // 기존 EqualInstallmentCalculator 형식 사용

--- a/bank/src/main/java/com/fisa/bank/domains/loan/presentation/controller/LoanController.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/presentation/controller/LoanController.java
@@ -126,7 +126,7 @@ public class LoanController {
   }
 
   @GetMapping("/prepayment-infos")
-  public ApiResponse<SuccessBody<List<PrepaymentInfoResponse>>> getPrepayment() {
+  public ApiResponse<SuccessBody<List<PrepaymentInfoResponse>>> getPrepaymentInfos() {
     log.info("선납 정보 조회");
     List<PrepaymentInfoResponse> prepaymentInfos = loanService.getPrepaymentInfos();
     return ApiResponseGenerator.success(ResponseCode.GET, prepaymentInfos);

--- a/bank/src/main/java/com/fisa/bank/domains/loan/presentation/controller/LoanController.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/presentation/controller/LoanController.java
@@ -25,13 +25,7 @@ import com.fisa.bank.domains.loan.application.dto.request.LoanApplyForRequest;
 import com.fisa.bank.domains.loan.application.dto.request.LoanAutoDepositUpdateRequest;
 import com.fisa.bank.domains.loan.application.dto.request.LoanMonthlyRepayRequest;
 import com.fisa.bank.domains.loan.application.dto.request.LoanProductCreateRequest;
-import com.fisa.bank.domains.loan.application.dto.response.LoanApplyforResponse;
-import com.fisa.bank.domains.loan.application.dto.response.LoanLedgerDetailResponse;
-import com.fisa.bank.domains.loan.application.dto.response.LoanLedgerResponse;
-import com.fisa.bank.domains.loan.application.dto.response.LoanProductCreateResponse;
-import com.fisa.bank.domains.loan.application.dto.response.LoanProductResponse;
-import com.fisa.bank.domains.loan.application.dto.response.LoanTransactionResponse;
-import com.fisa.bank.domains.loan.application.dto.response.PagedResponse;
+import com.fisa.bank.domains.loan.application.dto.response.*;
 import com.fisa.bank.domains.loan.application.service.LoanService;
 
 @Slf4j
@@ -129,5 +123,12 @@ public class LoanController {
     loanService.updateAutoDepositEnabled(loanLedgerId, request.getAutoDepositEnabled());
 
     return ApiResponseGenerator.success(ResponseCode.UPDATE);
+  }
+
+  @GetMapping("/prepayment-infos")
+  public ApiResponse<SuccessBody<List<PrepaymentInfoResponse>>> getPrepayment() {
+    log.info("선납 정보 조회");
+    List<PrepaymentInfoResponse> prepaymentInfos = loanService.getPrepaymentInfos();
+    return ApiResponseGenerator.success(ResponseCode.GET, prepaymentInfos);
   }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #112

## 작업 내용
- 선납 관련 정보 2가지를 반환하는 api
- 관련 정보 : 중도 상환 수수료, 남은 기간 이자 리스트
- api 호출을 한 번만 할 수 있도록 하나의 2가지 정보를 하나의 응답값으로 합쳤습니다.
- 남은 기간 계산을 코어뱅킹에서 함으로써 일관된 결과를 보장하도록 했습니다.
