### PR TITLE
[FEAT] 선납 정보 조회 응답값에 LoanLedgerId, 대출 상품 이름 추가

### DIFF
--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
@@ -153,7 +153,8 @@ public class SecurityFilterChainConfig {
                         "/api/accounts/{accountNumber}/transactions",
                         "/api/loans",
                         "/api/loans/ledger/{loanLedgerId:\\d+}",
-                        "/api/loans/ledgers")
+                        "/api/loans/ledgers",
+                        "/api/loans/prepayment-infos")
                     .requestMatchers(
                         HttpMethod.DELETE,
                         "/api/accounts/{accountNumber}",

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/dto/response/PrepaymentInfoResponse.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/dto/response/PrepaymentInfoResponse.java
@@ -9,6 +9,8 @@ import java.util.List;
 @Builder
 @Getter
 public class PrepaymentInfoResponse {
+  private final Long loanLedgerId;
+  private final String loanProductName;
   private final BigDecimal earlyRepayment;
   private final List<InterestDetailResponse> interestDetailResponses;
 }

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
@@ -375,6 +375,7 @@ public class LoanService {
 
     // 대출 별 선납 정보를 담을 리스트
     List<PrepaymentInfoResponse> prepaymentInfoResponses = new ArrayList<>();
+
     LocalDateTime now = LocalDateTime.now();
     for (LoanLedger loanLedger : loanLedgers) {
       if (EXCLUDED_REPAYMENT_STATUSES.contains(loanLedger.getRepaymentStatus())) continue;
@@ -389,6 +390,8 @@ public class LoanService {
 
       PrepaymentInfoResponse prepaymentInfoResponse =
           PrepaymentInfoResponse.builder()
+              .loanLedgerId(loanLedger.getLoanLedgerId().getValue())
+              .loanProductName(loanLedger.getLoanProduct().getName())
               .earlyRepayment(earlyRepayment.getEarlyPaidCost())
               .interestDetailResponses(interestDetailResponses)
               .build();


### PR DESCRIPTION
## 추가 사항
- 앱 화면 상에서 대출 상품 이름도 필요해서, 대출 원장 id와 대출 상품 이름도 반환되도록 응답값에 추가했습니다.