### PR TITLE
[FEAT] 연체 포함 모든 상환금 상환

### DIFF
--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/dto/response/LoanLedgerDetailResponse.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/dto/response/LoanLedgerDetailResponse.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.fisa.bank.domains.loan.application.model.MonthlyRepayment;
 import com.fisa.bank.domains.loan.persistence.entity.LoanLedger;
@@ -57,14 +58,14 @@ public class LoanLedgerDetailResponse {
   }
 
   public static LoanLedgerDetailResponse from(
-      LoanLedger loanLedger, MonthlyRepayment monthlyRepayment) {
+      LoanLedger loanLedger, List<MonthlyRepayment> monthlyRepayment) {
     return new LoanLedgerDetailResponse(
         loanLedger.getLoanProduct().getName(), // 엔티티 구조에 맞게 수정
         loanLedger.getPrincipal(),
         loanLedger.getRemainPrincipal(),
         loanLedger.getLoanProduct().getType(),
         loanLedger.getRepaymentType(),
-        monthlyRepayment.getMonthlyPayment(),
+        monthlyRepayment.get(monthlyRepayment.size() - 1).getMonthlyPayment(),
         loanLedger.getAccount().getAccountNumber(),
         loanLedger.isAutoDepositEnabled(),
         loanLedger.getLastRepaymentDate(),

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
@@ -241,21 +241,15 @@ public class LoanService {
 
     List<MonthlyRepayment> monthlyRepayments = calculatorService.calculate(loanLedger);
 
-    // 연체월 포함 모든 월 상환금
-    BigDecimal totalRepayment =
-        monthlyRepayments.stream()
-            .map(MonthlyRepayment::getMonthlyPayment)
-            .reduce(BigDecimal.ZERO, BigDecimal::add);
-    // 연체월 포함 모든 월 원금
-    BigDecimal totalPrincipal =
-        monthlyRepayments.stream()
-            .map(MonthlyRepayment::getPrincipalPayment)
-            .reduce(BigDecimal.ZERO, BigDecimal::add);
-    // 연체월 포함 모든 월 이자
-    BigDecimal totalInterest =
-        monthlyRepayments.stream()
-            .map(MonthlyRepayment::getInterestPayment)
-            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    // 연체월 포함 모든 월 상환금, 원금, 이자 합산
+    BigDecimal totalRepayment = BigDecimal.ZERO;
+    BigDecimal totalPrincipal = BigDecimal.ZERO;
+    BigDecimal totalInterest = BigDecimal.ZERO;
+    for (MonthlyRepayment repayment : monthlyRepayments) {
+      totalRepayment = totalRepayment.add(repayment.getMonthlyPayment());
+      totalPrincipal = totalPrincipal.add(repayment.getPrincipalPayment());
+      totalInterest = totalInterest.add(repayment.getInterestPayment());
+    }
 
     MonthlyRepayment monthlyRepayment =
         new MonthlyRepayment(

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
@@ -214,6 +214,8 @@ public class LoanService {
             account,
             request.getAutoDepositEnabled());
 
+    loanLedger.setLastRepaymentDate(loanLedger.getCreatedAt());
+
     // 대출 이력성 테이블에 저장 LoanTransaction
     LoanTransaction loanTransaction =
         LoanTransactionFactory.createLoan(loanLedger, remainPrincipal, startDate);

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
@@ -237,17 +237,42 @@ public class LoanService {
 
     LoanLedger loanLedger = loanReader.findLoanLedgerById(loanLedgerId);
 
-    MonthlyRepayment monthlyRepayment = calculatorService.calculate(loanLedger);
+    LocalDateTime now = LocalDateTime.now();
 
+    List<MonthlyRepayment> monthlyRepayments = calculatorService.calculate(loanLedger);
+
+    // 연체월 포함 모든 월 상환금
+    BigDecimal totalRepayment =
+        monthlyRepayments.stream()
+            .map(MonthlyRepayment::getMonthlyPayment)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    // 연체월 포함 모든 월 원금
+    BigDecimal totalPrincipal =
+        monthlyRepayments.stream()
+            .map(MonthlyRepayment::getPrincipalPayment)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    // 연체월 포함 모든 월 이자
+    BigDecimal totalInterest =
+        monthlyRepayments.stream()
+            .map(MonthlyRepayment::getInterestPayment)
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+    MonthlyRepayment monthlyRepayment =
+        new MonthlyRepayment(
+            loanLedger.getTerm(),
+            totalPrincipal,
+            totalInterest,
+            totalRepayment,
+            loanLedger.getRemainPrincipal().subtract(totalPrincipal),
+            now);
     // 납입 금액이 상환금보다 작은지 확인
-    if (request.getAmount().compareTo(monthlyRepayment.getMonthlyPayment()) < 0) {
-      throw new InsufficientRepaymentException(
-          request.getAmount(), monthlyRepayment.getMonthlyPayment());
+    if (request.getAmount().compareTo(totalRepayment) < 0) {
+      throw new InsufficientRepaymentException(request.getAmount(), totalRepayment);
     }
 
     Account account = loanLedger.getAccount();
 
-    if (account.getBalance().compareTo(monthlyRepayment.getMonthlyPayment()) < 0) {
+    if (account.getBalance().compareTo(totalRepayment) < 0) {
       throw new InsufficientBalanceException();
     }
 
@@ -259,18 +284,14 @@ public class LoanService {
     loanLedger.updateLoanLedger(
         UpdateLoanLedgerParam.builder()
             .remainPrincipal(monthlyRepayment.getRemainPrincipal())
-            .lastRepaymentDate(lastRepaymentDate)
+            .lastRepaymentDate(monthlyRepayment.getRepaymentDate())
             .nextRepaymentDate(nextRepaymentDate)
             .status(loanLedger.getRepaymentStatus())
             .build());
 
     // 이력성 테이블에도 저장
     LoanTransaction loanTransaction =
-        LoanTransactionFactory.createRepay(
-            loanLedger,
-            monthlyRepayment.getMonthlyPayment(),
-            monthlyRepayment,
-            LocalDateTime.now());
+        LoanTransactionFactory.createRepay(loanLedger, totalRepayment, monthlyRepayment, now);
 
     loanTransactionRepository.save(loanTransaction);
 
@@ -350,7 +371,7 @@ public class LoanService {
   public LoanLedgerDetailResponse getLoanLedgerDetail(Long loanLedgerId) {
     LoanLedger loanLedger = loanReader.findLoanLedgerById(loanLedgerId);
 
-    MonthlyRepayment monthlyRepayment = calculatorService.calculate(loanLedger);
+    List<MonthlyRepayment> monthlyRepayment = calculatorService.calculate(loanLedger);
     return LoanLedgerDetailResponse.from(loanLedger, monthlyRepayment);
   }
 

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/calculator/CalculatorService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/calculator/CalculatorService.java
@@ -30,19 +30,53 @@ public class CalculatorService {
     calculators.put(RepaymentType.BULLET, new BulletCalculator());
   }
 
-  public MonthlyRepayment calculate(LoanLedger loanLedger) {
+  public List<MonthlyRepayment> calculate(LoanLedger loanLedger) {
     LoanCalculator calculator = calculators.get(loanLedger.getRepaymentType());
     if (calculator == null) {
       throw new UnknownCalculatorException();
     }
-    return calculator.calculate(
-        loanLedger.getPrincipal(),
-        loanLedger.getRemainPrincipal(),
-        loanLedger.getCompletedInterest().divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP),
-        loanLedger.getTerm() * 12, // 연 -> 개월로 변경
-        1, // currentTerm은 실제로 사용되지 않음
-        loanLedger.getNextRepaymentDate(),
-        loanLedger.getLoanEndDate());
+    List<MonthlyRepayment> repayments = new ArrayList<>();
+
+    // 연체월까지 포함해서 계산하기 위해 일시적으로 바뀌는 값들
+    BigDecimal tempRemainPrincipal = loanLedger.getRemainPrincipal();
+    LocalDateTime lastRepaymentDate = loanLedger.getLastRepaymentDate(); // 마지막 상환일
+    LocalDateTime tempNextRepaymentDate = loanLedger.getNextRepaymentDate();
+
+    int monthsOverdue =
+        (int)
+            ChronoUnit.MONTHS.between(
+                lastRepaymentDate.toLocalDate(), tempNextRepaymentDate.toLocalDate());
+    monthsOverdue = Math.max(monthsOverdue, 1); // 최소 1개월
+
+    for (int i = 0; i < monthsOverdue; i++) {
+      MonthlyRepayment monthlyRepayment =
+          calculator.calculate(
+              loanLedger.getPrincipal(),
+              tempRemainPrincipal,
+              loanLedger
+                  .getCompletedInterest()
+                  .divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP),
+              loanLedger.getTerm() * 12, // 연 -> 개월로 변경
+              1, // currentTerm은 실제로 사용되지 않음
+              tempNextRepaymentDate,
+              loanLedger.getLoanEndDate());
+
+      repayments.add(monthlyRepayment);
+
+      // 임시 변수 업데이트 (DB는 건드리지 않음)
+      tempRemainPrincipal = monthlyRepayment.getRemainPrincipal();
+      tempNextRepaymentDate = tempNextRepaymentDate.plusMonths(1);
+    }
+
+    // 테스트용 출력 코드
+    for (int i = 0; i < repayments.size(); i++) {
+      MonthlyRepayment m = repayments.get(i);
+      System.out.printf(
+          "Month %d: principal=%s, interest=%s, remainPrincipal=%s%n",
+          i + 1, m.getPrincipalPayment(), m.getInterestPayment(), m.getRemainPrincipal());
+    }
+
+    return repayments;
   }
 
   /**

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/calculator/CalculatorService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/calculator/CalculatorService.java
@@ -68,14 +68,6 @@ public class CalculatorService {
       tempNextRepaymentDate = tempNextRepaymentDate.plusMonths(1);
     }
 
-    // 테스트용 출력 코드
-    for (int i = 0; i < repayments.size(); i++) {
-      MonthlyRepayment m = repayments.get(i);
-      System.out.printf(
-          "Month %d: principal=%s, interest=%s, remainPrincipal=%s%n",
-          i + 1, m.getPrincipalPayment(), m.getInterestPayment(), m.getRemainPrincipal());
-    }
-
     return repayments;
   }
 

--- a/bank/src/main/java/com/fisa/bank/domains/loan/persistence/entity/LoanLedger.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/persistence/entity/LoanLedger.java
@@ -12,11 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -100,7 +96,7 @@ public class LoanLedger extends BaseEntity {
 
   // 다음 상환, 마지막 거래 일시, 상환 마감 기한
   private LocalDateTime nextRepaymentDate;
-  private LocalDateTime lastRepaymentDate;
+  @Setter private LocalDateTime lastRepaymentDate;
 
   @Column(nullable = false)
   private LocalDateTime loanEndDate;


### PR DESCRIPTION
## 수정한 사항
- 기존 : 상환 시 해당 월에 대한 상환금만 계산하여 상환
- 변경 : 연체됐을 경우를 고려하여 마지막 납입일 ~다음 상환일까지 모든 상환금을 상환하도록 변경