### PR TITLE
[FEAT] 관리자 기능 추가

### DIFF
--- a/bank/src/main/java/com/fisa/bank/domains/admin/application/dto/AdminUserSummaryResponse.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/application/dto/AdminUserSummaryResponse.java
@@ -1,4 +1,3 @@
 package com.fisa.bank.domains.admin.application.dto;
 
 public record AdminUserSummaryResponse(Long userId, String name, String loginId) {}
-

--- a/bank/src/main/java/com/fisa/bank/domains/admin/application/dto/AdminUserSummaryResponse.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/application/dto/AdminUserSummaryResponse.java
@@ -1,0 +1,4 @@
+package com.fisa.bank.domains.admin.application.dto;
+
+public record AdminUserSummaryResponse(Long userId, String name, String loginId) {}
+

--- a/bank/src/main/java/com/fisa/bank/domains/admin/application/service/AdminUserService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/application/service/AdminUserService.java
@@ -3,10 +3,10 @@ package com.fisa.bank.domains.admin.application.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.fisa.bank.domains.admin.application.dto.AdminUserSummaryResponse;
 import com.fisa.bank.domains.user.persistence.repository.UserRepository;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class AdminUserService {

--- a/bank/src/main/java/com/fisa/bank/domains/admin/application/service/AdminUserService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/application/service/AdminUserService.java
@@ -19,7 +19,7 @@ public class AdminUserService {
 
   @Transactional(readOnly = true)
   public List<AdminUserSummaryResponse> getUsers() {
-    return userRepository.findAll().stream()
+    return userRepository.findAllNonAdmin().stream()
         .map(
             user ->
                 new AdminUserSummaryResponse(

--- a/bank/src/main/java/com/fisa/bank/domains/admin/application/service/AdminUserService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/application/service/AdminUserService.java
@@ -1,0 +1,25 @@
+package com.fisa.bank.domains.admin.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.fisa.bank.domains.admin.application.dto.AdminUserSummaryResponse;
+import com.fisa.bank.domains.user.persistence.repository.UserRepository;
+
+@Service
+public class AdminUserService {
+
+  private final UserRepository userRepository;
+
+  public AdminUserService(UserRepository userRepository) {
+    this.userRepository = userRepository;
+  }
+
+  public List<AdminUserSummaryResponse> getUsers() {
+    return userRepository.findAll().stream()
+        .map(user -> new AdminUserSummaryResponse(user.getUserId().getValue(), user.getName(), user.getUserAuth().getLoginId()))
+        .toList();
+  }
+}
+

--- a/bank/src/main/java/com/fisa/bank/domains/admin/application/service/AdminUserService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/application/service/AdminUserService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.fisa.bank.domains.admin.application.dto.AdminUserSummaryResponse;
 import com.fisa.bank.domains.user.persistence.repository.UserRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class AdminUserService {
@@ -16,6 +17,7 @@ public class AdminUserService {
     this.userRepository = userRepository;
   }
 
+  @Transactional(readOnly = true)
   public List<AdminUserSummaryResponse> getUsers() {
     return userRepository.findAll().stream()
         .map(

--- a/bank/src/main/java/com/fisa/bank/domains/admin/application/service/AdminUserService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/application/service/AdminUserService.java
@@ -18,8 +18,10 @@ public class AdminUserService {
 
   public List<AdminUserSummaryResponse> getUsers() {
     return userRepository.findAll().stream()
-        .map(user -> new AdminUserSummaryResponse(user.getUserId().getValue(), user.getName(), user.getUserAuth().getLoginId()))
+        .map(
+            user ->
+                new AdminUserSummaryResponse(
+                    user.getUserId().getValue(), user.getName(), user.getUserAuth().getLoginId()))
         .toList();
   }
 }
-

--- a/bank/src/main/java/com/fisa/bank/domains/admin/application/util/AdminUserInitializer.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/application/util/AdminUserInitializer.java
@@ -1,8 +1,13 @@
-package com.fisa.bank.domains.user.persistence.seed;
+package com.fisa.bank.domains.admin.application.util;
 
+import com.fisa.bank.domains.user.persistence.entity.CreditRating;
+import com.fisa.bank.domains.user.persistence.entity.CustomerLevel;
+import com.fisa.bank.domains.user.persistence.entity.User;
+import com.fisa.bank.domains.user.persistence.entity.UserAuth;
+import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
+import com.fisa.bank.domains.user.persistence.repository.UserRepository;
 import java.math.BigInteger;
 import java.time.LocalDateTime;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -12,13 +17,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.fisa.bank.domains.user.persistence.entity.CreditRating;
-import com.fisa.bank.domains.user.persistence.entity.CustomerLevel;
-import com.fisa.bank.domains.user.persistence.entity.User;
-import com.fisa.bank.domains.user.persistence.entity.UserAuth;
-import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
-import com.fisa.bank.domains.user.persistence.repository.UserRepository;
 
 /**
  * 애플리케이션 구동 시 관리자 계정을 보장하는 시드 러너.

--- a/bank/src/main/java/com/fisa/bank/domains/admin/application/util/AdminUserInitializer.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/application/util/AdminUserInitializer.java
@@ -1,13 +1,8 @@
 package com.fisa.bank.domains.admin.application.util;
 
-import com.fisa.bank.domains.user.persistence.entity.CreditRating;
-import com.fisa.bank.domains.user.persistence.entity.CustomerLevel;
-import com.fisa.bank.domains.user.persistence.entity.User;
-import com.fisa.bank.domains.user.persistence.entity.UserAuth;
-import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
-import com.fisa.bank.domains.user.persistence.repository.UserRepository;
 import java.math.BigInteger;
 import java.time.LocalDateTime;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -17,6 +12,13 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.fisa.bank.domains.user.persistence.entity.CreditRating;
+import com.fisa.bank.domains.user.persistence.entity.CustomerLevel;
+import com.fisa.bank.domains.user.persistence.entity.User;
+import com.fisa.bank.domains.user.persistence.entity.UserAuth;
+import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
+import com.fisa.bank.domains.user.persistence.repository.UserRepository;
 
 /**
  * 애플리케이션 구동 시 관리자 계정을 보장하는 시드 러너.
@@ -54,9 +56,7 @@ public class AdminUserInitializer implements CommandLineRunner {
       return; // 이미 존재하면 아무 것도 하지 않음
     }
 
-      String rawPassword = adminSeedPassword.isBlank()
-              ? DEFAULT_PASSWORD
-              : adminSeedPassword.trim();
+    String rawPassword = adminSeedPassword.isBlank() ? DEFAULT_PASSWORD : adminSeedPassword.trim();
     String encodedPassword = passwordEncoder.encode(rawPassword);
 
     UserAuth adminAuth = UserAuth.createAdmin(DEFAULT_LOGIN_ID, encodedPassword);

--- a/bank/src/main/java/com/fisa/bank/domains/admin/application/util/AdminUserInitializer.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/application/util/AdminUserInitializer.java
@@ -54,9 +54,9 @@ public class AdminUserInitializer implements CommandLineRunner {
       return; // 이미 존재하면 아무 것도 하지 않음
     }
 
-    String rawPassword = adminSeedPassword == null || adminSeedPassword.isBlank()
-        ? DEFAULT_PASSWORD
-        : adminSeedPassword.trim();
+      String rawPassword = adminSeedPassword.isBlank()
+              ? DEFAULT_PASSWORD
+              : adminSeedPassword.trim();
     String encodedPassword = passwordEncoder.encode(rawPassword);
 
     UserAuth adminAuth = UserAuth.createAdmin(DEFAULT_LOGIN_ID, encodedPassword);

--- a/bank/src/main/java/com/fisa/bank/domains/admin/application/util/AdminUserInitializer.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/application/util/AdminUserInitializer.java
@@ -76,6 +76,6 @@ public class AdminUserInitializer implements CommandLineRunner {
     // 먼저 인증 엔티티를 저장한 뒤 User를 저장
     userAuthRepository.save(adminAuth);
     userRepository.save(adminUser);
-    log.info("Seeded admin account with loginId='{}'", DEFAULT_LOGIN_ID);
+    log.info("관리자 계정을 생성했습니다. loginId='{}'", DEFAULT_LOGIN_ID);
   }
 }

--- a/bank/src/main/java/com/fisa/bank/domains/admin/presentation/controller/AdminController.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/presentation/controller/AdminController.java
@@ -136,7 +136,7 @@ public class AdminController {
   @Operation(summary = "관리자: 대출 상환", description = "특정 대출을 상환 처리합니다.")
   @PostMapping("/loans/{loanLedgerId}/repayment")
   public ApiResponse<SuccessBody<LoanTransactionResponse>> repayLoan(
-      @PathVariable Long loanLedgerId, @RequestBody LoanMonthlyRepayRequest request) {
+      @PathVariable Long loanLedgerId, @RequestBody @Valid LoanMonthlyRepayRequest request) {
     LoanTransactionResponse response = loanService.repayMonthlyLoan(loanLedgerId, request);
     return ApiResponseGenerator.success(ResponseCode.UPDATE, response);
   }

--- a/bank/src/main/java/com/fisa/bank/domains/admin/presentation/controller/AdminController.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/presentation/controller/AdminController.java
@@ -63,9 +63,7 @@ public class AdminController {
   public ApiResponse<SuccessBody<AccountResponse>> createAccountForUser(
       @PathVariable Long userId, @RequestParam(defaultValue = "false") boolean income) {
     AccountResponse response =
-        income
-            ? accountService.createIncomeAccount(userId)
-            : accountService.createAccount(userId);
+        income ? accountService.createIncomeAccount(userId) : accountService.createAccount(userId);
     return ApiResponseGenerator.success(ResponseCode.CREATE, response);
   }
 
@@ -88,7 +86,8 @@ public class AdminController {
   @PostMapping("/accounts/{accountNumber}/withdraw")
   public ApiResponse<SuccessBody<AccountTransactionResponse>> withdraw(
       @PathVariable String accountNumber, @Valid @RequestBody AccountWithdrawRequest request) {
-    AccountTransactionResponse response = accountTransactionService.withdraw(accountNumber, request);
+    AccountTransactionResponse response =
+        accountTransactionService.withdraw(accountNumber, request);
     return ApiResponseGenerator.success(ResponseCode.UPDATE, response);
   }
 

--- a/bank/src/main/java/com/fisa/bank/domains/admin/presentation/controller/AdminController.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/presentation/controller/AdminController.java
@@ -1,0 +1,151 @@
+package com.fisa.bank.domains.admin.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fisa.bank.domains.account.application.dto.request.AccountDepositRequest;
+import com.fisa.bank.domains.account.application.dto.request.AccountWithdrawRequest;
+import com.fisa.bank.domains.account.application.dto.request.CardPaymentRequest;
+import com.fisa.bank.domains.account.application.dto.request.TransferRequest;
+import com.fisa.bank.domains.account.application.dto.response.AccountListResponse;
+import com.fisa.bank.domains.account.application.dto.response.AccountResponse;
+import com.fisa.bank.domains.account.application.dto.response.AccountTransactionResponse;
+import com.fisa.bank.domains.account.application.dto.response.CardPaymentResponse;
+import com.fisa.bank.domains.account.application.dto.response.TransferResponse;
+import com.fisa.bank.domains.account.application.service.AccountService;
+import com.fisa.bank.domains.account.application.service.AccountTransactionService;
+import com.fisa.bank.domains.admin.application.dto.AdminUserSummaryResponse;
+import com.fisa.bank.domains.admin.application.service.AdminUserService;
+import com.fisa.bank.domains.common.presentation.response.ApiResponse;
+import com.fisa.bank.domains.common.presentation.response.ApiResponseGenerator;
+import com.fisa.bank.domains.common.presentation.response.body.SuccessBody;
+import com.fisa.bank.domains.common.presentation.response.code.ResponseCode;
+import com.fisa.bank.domains.loan.application.dto.request.LoanApplyForRequest;
+import com.fisa.bank.domains.loan.application.dto.request.LoanMonthlyRepayRequest;
+import com.fisa.bank.domains.loan.application.dto.response.LoanApplyforResponse;
+import com.fisa.bank.domains.loan.application.dto.response.LoanLedgerResponse;
+import com.fisa.bank.domains.loan.application.dto.response.LoanTransactionResponse;
+import com.fisa.bank.domains.loan.application.service.LoanService;
+
+@Tag(name = "Admin", description = "관리자 전용 API")
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+  private final AccountService accountService;
+  private final AccountTransactionService accountTransactionService;
+  private final LoanService loanService;
+  private final AdminUserService adminUserService;
+
+  @Operation(summary = "관리자: 사용자 목록", description = "모든 사용자 목록을 조회합니다.")
+  @GetMapping("/users")
+  public ApiResponse<SuccessBody<List<AdminUserSummaryResponse>>> getUsers() {
+    List<AdminUserSummaryResponse> users = adminUserService.getUsers();
+    return ApiResponseGenerator.success(ResponseCode.GET, users);
+  }
+
+  @Operation(summary = "관리자: 계좌 생성", description = "특정 사용자의 계좌를 생성합니다. income=true면 급여계좌.")
+  @PostMapping("/users/{userId}/accounts")
+  public ApiResponse<SuccessBody<AccountResponse>> createAccountForUser(
+      @PathVariable Long userId, @RequestParam(defaultValue = "false") boolean income) {
+    AccountResponse response =
+        income
+            ? accountService.createIncomeAccount(userId)
+            : accountService.createAccount(userId);
+    return ApiResponseGenerator.success(ResponseCode.CREATE, response);
+  }
+
+  @Operation(summary = "관리자: 사용자 계좌 목록", description = "특정 사용자의 모든 계좌를 조회합니다.")
+  @GetMapping("/users/{userId}/accounts")
+  public ApiResponse<SuccessBody<List<AccountListResponse>>> getUserAccounts(
+      @PathVariable Long userId) {
+    List<AccountListResponse> accounts = accountService.getAccountsByUserId(userId);
+    return ApiResponseGenerator.success(ResponseCode.GET, accounts);
+  }
+
+  @Operation(summary = "관리자: 계좌 삭제", description = "특정 계좌를 삭제합니다.")
+  @DeleteMapping("/accounts/{accountNumber}")
+  public ApiResponse<SuccessBody<Void>> deleteAccount(@PathVariable String accountNumber) {
+    accountService.deleteAccount(accountNumber);
+    return ApiResponseGenerator.success(ResponseCode.DELETE);
+  }
+
+  @Operation(summary = "관리자: 출금", description = "특정 계좌에서 금액을 출금합니다.")
+  @PostMapping("/accounts/{accountNumber}/withdraw")
+  public ApiResponse<SuccessBody<AccountTransactionResponse>> withdraw(
+      @PathVariable String accountNumber, @Valid @RequestBody AccountWithdrawRequest request) {
+    AccountTransactionResponse response = accountTransactionService.withdraw(accountNumber, request);
+    return ApiResponseGenerator.success(ResponseCode.UPDATE, response);
+  }
+
+  @Operation(summary = "관리자: 입금", description = "특정 계좌에 금액을 입금합니다.")
+  @PostMapping("/accounts/{accountNumber}/deposit")
+  public ApiResponse<SuccessBody<AccountTransactionResponse>> deposit(
+      @PathVariable String accountNumber, @Valid @RequestBody AccountDepositRequest request) {
+    AccountTransactionResponse response = accountTransactionService.deposit(accountNumber, request);
+    return ApiResponseGenerator.success(ResponseCode.UPDATE, response);
+  }
+
+  @Operation(summary = "관리자: 송금", description = "특정 계좌에서 다른 계좌로 송금합니다.")
+  @PostMapping("/accounts/transfer")
+  public ApiResponse<SuccessBody<TransferResponse>> transfer(
+      @Valid @RequestBody TransferRequest request) {
+    TransferResponse response = accountTransactionService.transfer(request);
+    return ApiResponseGenerator.success(ResponseCode.UPDATE, response);
+  }
+
+  @Operation(summary = "관리자: 카드 결제", description = "특정 계좌로 카드 결제를 처리합니다.")
+  @PostMapping("/accounts/{accountNumber}/pay")
+  public ApiResponse<SuccessBody<CardPaymentResponse>> pay(
+      @PathVariable String accountNumber, @Valid @RequestBody CardPaymentRequest request) {
+    CardPaymentResponse response = accountTransactionService.payByCard(accountNumber, request);
+    return ApiResponseGenerator.success(ResponseCode.UPDATE, response);
+  }
+
+  @Operation(summary = "관리자: 대출 가입", description = "특정 사용자를 지정해 대출을 가입합니다.")
+  @PostMapping("/users/{userId}/loans/{loanProductId}")
+  public ApiResponse<SuccessBody<LoanApplyforResponse>> applyForLoan(
+      @PathVariable Long userId,
+      @PathVariable Long loanProductId,
+      @Valid @RequestBody LoanApplyForRequest request) {
+    LoanApplyforResponse response = loanService.applyForLoanAsAdmin(userId, request, loanProductId);
+    return ApiResponseGenerator.success(ResponseCode.CREATE, response);
+  }
+
+  @Operation(summary = "관리자: 사용자 대출 목록", description = "특정 사용자의 대출 원장 목록을 조회합니다.")
+  @GetMapping("/users/{userId}/loans")
+  public ApiResponse<SuccessBody<List<LoanLedgerResponse>>> getLoanLedgers(
+      @PathVariable Long userId) {
+    List<LoanLedgerResponse> ledgers = loanService.getLoanLedgersByUser(userId);
+    return ApiResponseGenerator.success(ResponseCode.GET, ledgers);
+  }
+
+  @Operation(summary = "관리자: 대출 상환", description = "특정 대출을 상환 처리합니다.")
+  @PostMapping("/loans/{loanLedgerId}/repayment")
+  public ApiResponse<SuccessBody<LoanTransactionResponse>> repayLoan(
+      @PathVariable Long loanLedgerId, @RequestBody LoanMonthlyRepayRequest request) {
+    LoanTransactionResponse response = loanService.repayMonthlyLoan(loanLedgerId, request);
+    return ApiResponseGenerator.success(ResponseCode.UPDATE, response);
+  }
+
+  @Operation(summary = "관리자: 대출 해지", description = "특정 대출을 해지합니다.")
+  @DeleteMapping("/loans/{loanLedgerId}")
+  public ApiResponse<SuccessBody<Void>> cancelLoan(@PathVariable Long loanLedgerId) {
+    loanService.cancelLoan(loanLedgerId);
+    return ApiResponseGenerator.success(ResponseCode.DELETE);
+  }
+}

--- a/bank/src/main/java/com/fisa/bank/domains/admin/presentation/controller/AdminPageController.java
+++ b/bank/src/main/java/com/fisa/bank/domains/admin/presentation/controller/AdminPageController.java
@@ -1,0 +1,33 @@
+package com.fisa.bank.domains.admin.presentation.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class AdminPageController {
+
+  @GetMapping("/admin")
+  public String adminIndex() {
+    return "admin/index";
+  }
+
+  @GetMapping("/admin/accounts")
+  public String adminAccounts() {
+    return "admin/accounts";
+  }
+
+  @GetMapping("/admin/loans")
+  public String adminLoans() {
+    return "admin/loans";
+  }
+
+  @GetMapping("/admin/products")
+  public String adminProducts() {
+    return "admin/products";
+  }
+
+  @GetMapping("/admin/login")
+  public String adminLogin() {
+    return "admin/login";
+  }
+}

--- a/bank/src/main/java/com/fisa/bank/domains/common/aop/aspect/OwnershipAspect.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/aop/aspect/OwnershipAspect.java
@@ -9,6 +9,8 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import com.fisa.bank.domains.account.application.exception.AccessDeniedException;
@@ -32,6 +34,10 @@ public class OwnershipAspect {
 
   @Before("@annotation(verifyOwner)")
   public void verifyOwnership(JoinPoint joinPoint, VerifyOwner verifyOwner) {
+    if (isAdmin()) {
+      return; // ADMIN은 소유권 검사를 건너뜀
+    }
+
     Object idValue = extractParamValue(joinPoint, verifyOwner.idParam());
 
     switch (verifyOwner.domain()) {
@@ -57,6 +63,15 @@ public class OwnershipAspect {
         }
       }
     }
+  }
+
+  private boolean isAdmin() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null || authentication.getAuthorities() == null) {
+      return false;
+    }
+    return authentication.getAuthorities().stream()
+        .anyMatch(authority -> "ROLE_ADMIN".equals(authority.getAuthority()));
   }
 
   private Object extractParamValue(JoinPoint joinPoint, String paramName) {

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
@@ -113,8 +113,7 @@ public class SecurityFilterChainConfig {
                         "/v3/api-docs/**", // TODO: Swagger 전용 필터체인으로 분리
                         "/swagger-resources/**", // TODO: Swagger 전용 필터체인으로 분리
                         "/admin/login",
-                        "/admin/**"
-                        )
+                        "/admin/**")
                     .requestMatchers(HttpMethod.POST, "/api/loans", "/api/login", "/api/users")
                     .requestMatchers(HttpMethod.DELETE, "/api/loans/products/{loanProductId:\\d+}"))
         .authorizeHttpRequests(request -> request.anyRequest().permitAll());

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
@@ -109,14 +109,12 @@ public class SecurityFilterChainConfig {
                         "/api/loans/products",
                         "/api/loans/{loanProductId:\\d+}",
                         "/api/interests/{loanProductId:\\d+}",
-                        "/swagger-ui/**", // TODO: Swagger 전용 필터체인으로 분리
-                        "/v3/api-docs/**", // TODO: Swagger 전용 필터체인으로 분리
-                        "/swagger-resources/**", // TODO: Swagger 전용 필터체인으로 분리
-                        "/admin/login",
-                        "/admin/**")
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**",
+                        "/swagger-resources/**")
                     .requestMatchers(HttpMethod.POST, "/api/loans", "/api/login", "/api/users")
                     .requestMatchers(HttpMethod.DELETE, "/api/loans/products/{loanProductId:\\d+}"))
-        .authorizeHttpRequests(request -> request.anyRequest().permitAll());
+        .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
 
     http.addFilterBefore(loginFilter, UsernamePasswordAuthenticationFilter.class); // login 전용 필터
     http.oauth2ResourceServer(AbstractHttpConfigurer::disable);
@@ -126,6 +124,37 @@ public class SecurityFilterChainConfig {
 
   @Bean
   @Order(3)
+  // [관리자용] 관리자 전용 엔드포인트 시큐리티 필터체인
+  public SecurityFilterChain admin(
+      HttpSecurity http,
+      @Qualifier("authenticatedFilter") AuthenticationFilter authenticationFilter)
+      throws Exception {
+
+    commonConfiguration(http);
+
+    http.securityMatchers(
+            matcher ->
+                matcher
+                    .requestMatchers(
+                        HttpMethod.GET, "/admin/**")
+                    .requestMatchers("/admin/login")
+                    .requestMatchers("/api/admin/**"))
+        .authorizeHttpRequests(
+            auth ->
+                auth
+                    .requestMatchers("/admin/login")
+                    .permitAll()
+                    .anyRequest()
+                    .hasRole("ADMIN"));
+
+    http.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    http.exceptionHandling(ex -> ex.authenticationEntryPoint(requiredAuthenticationEntryPoint));
+    http.oauth2ResourceServer(AbstractHttpConfigurer::disable);
+    return http.build();
+  }
+
+  @Bean
+  @Order(4)
   // [일반 사용자용] 인증이 필요한 엔드포인트 시큐리티 필터체인
   public SecurityFilterChain authenticated(
       HttpSecurity http,
@@ -163,15 +192,9 @@ public class SecurityFilterChainConfig {
                         "/api/accounts/{accountNumber}",
                         "/api/loans/{loanLedgerId:\\d+}")
                     .requestMatchers(
-                        HttpMethod.PATCH, "/api/loans/{loanLedgerId:\\d+}/auto-deposit")
-                    .requestMatchers("/api/admin/**"))
+                        HttpMethod.PATCH, "/api/loans/{loanLedgerId:\\d+}/auto-deposit"))
         .authorizeHttpRequests(
-            request ->
-                request
-                    .requestMatchers("/api/admin/**")
-                    .hasRole("ADMIN")
-                    .anyRequest()
-                    .authenticated());
+            request -> request.anyRequest().authenticated());
 
     http.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
     http.exceptionHandling(ex -> ex.authenticationEntryPoint(requiredAuthenticationEntryPoint));
@@ -181,7 +204,7 @@ public class SecurityFilterChainConfig {
 
   /** 시큐리티 기본 로그인 및 에러 리다이렉트 필터체인 */
   @Bean
-  @Order(4)
+  @Order(5)
   public SecurityFilterChain loginFilterChain(
       HttpSecurity http,
       @Qualifier("UsernamePasswordAuthenticationProvider")
@@ -201,7 +224,7 @@ public class SecurityFilterChainConfig {
   }
 
   @Bean
-  @Order(5)
+  @Order(6)
   public SecurityFilterChain unknownFilterChain(
       HttpSecurity httpSecurity, UnknownEndPointFilter unknownEndPointFilter) throws Exception {
     httpSecurity.securityMatcher("/**");

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
@@ -156,7 +156,8 @@ public class SecurityFilterChainConfig {
                         "/admin/login",
                         "/admin/accounts",
                         "/admin/loans",
-                        "/admin/products")
+                        "/admin/products",
+                        "/js/**")
                     .requestMatchers(
                         HttpMethod.POST, "/admin/accounts", "/admin/loans", "/admin/products")
                     .requestMatchers(

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
@@ -136,9 +136,44 @@ public class SecurityFilterChainConfig {
             matcher ->
                 matcher
                     .requestMatchers(
-                        HttpMethod.GET, "/admin/**")
-                    .requestMatchers("/admin/login")
-                    .requestMatchers("/api/admin/**"))
+                        HttpMethod.GET,
+                        "/admin",
+                        "/admin/login",
+                        "/admin/accounts",
+                        "/admin/loans",
+                        "/admin/products")
+                    .requestMatchers(
+                        HttpMethod.POST,
+                        "/admin/accounts",
+                        "/admin/loans",
+                        "/admin/products")
+                    .requestMatchers(
+                        HttpMethod.PUT,
+                        "/admin/accounts",
+                        "/admin/loans",
+                        "/admin/products")
+                    .requestMatchers(
+                        HttpMethod.DELETE,
+                        "/admin/accounts",
+                        "/admin/loans",
+                        "/admin/products")
+                    .requestMatchers(
+                        HttpMethod.GET,
+                        "/api/admin/users",
+                        "/api/admin/users/*/accounts",
+                        "/api/admin/users/*/loans",
+                        "/api/admin/loans/*")
+                    .requestMatchers(
+                        HttpMethod.POST,
+                        "/api/admin/users/*/accounts",
+                        "/api/admin/accounts/*/withdraw",
+                        "/api/admin/accounts/*/deposit",
+                        "/api/admin/accounts/transfer",
+                        "/api/admin/accounts/*/pay",
+                        "/api/admin/users/*/loans/*",
+                        "/api/admin/loans/*/repayment")
+                    .requestMatchers(
+                        HttpMethod.DELETE, "/api/admin/accounts/*", "/api/admin/loans/*"))
         .authorizeHttpRequests(
             auth ->
                 auth

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
@@ -30,6 +30,7 @@ import com.fisa.bank.domains.common.config.security.resource.RequiredAuthenticat
 import com.fisa.bank.domains.common.config.security.resource.UnknownEndPointFilter;
 import com.fisa.bank.domains.common.config.security.resource.LogoutCookieFilter;
 import com.fisa.bank.domains.common.config.security.resource.RefreshTokenFilter;
+import com.fisa.bank.domains.common.config.security.resource.AdminPageAuthFilter;
 
 @Configuration
 @RequiredArgsConstructor
@@ -37,7 +38,7 @@ import com.fisa.bank.domains.common.config.security.resource.RefreshTokenFilter;
 public class SecurityFilterChainConfig {
 
   private final RequiredAuthenticationEntryPoint requiredAuthenticationEntryPoint;
-
+  private final AdminPageAuthFilter adminPageAuthFilter;
   @Bean
   @Order(1)
   // Authorization Server 필터 체인 설정
@@ -194,6 +195,7 @@ public class SecurityFilterChainConfig {
                     .hasRole("ADMIN"));
 
     http.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+    http.addFilterBefore(adminPageAuthFilter, UsernamePasswordAuthenticationFilter.class);
     http.exceptionHandling(ex -> ex.authenticationEntryPoint(requiredAuthenticationEntryPoint));
     http.oauth2ResourceServer(AbstractHttpConfigurer::disable);
     return http.build();

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
@@ -38,7 +38,7 @@ import com.fisa.bank.domains.common.config.security.resource.AdminPageAuthFilter
 public class SecurityFilterChainConfig {
 
   private final RequiredAuthenticationEntryPoint requiredAuthenticationEntryPoint;
-  private final AdminPageAuthFilter adminPageAuthFilter;
+
   @Bean
   @Order(1)
   // Authorization Server 필터 체인 설정
@@ -139,7 +139,8 @@ public class SecurityFilterChainConfig {
   // [관리자용] 관리자 전용 엔드포인트 시큐리티 필터체인
   public SecurityFilterChain admin(
       HttpSecurity http,
-      @Qualifier("authenticatedFilter") AuthenticationFilter authenticationFilter)
+      @Qualifier("authenticatedFilter") AuthenticationFilter authenticationFilter,
+      AdminPageAuthFilter adminPageAuthFilter)
       throws Exception {
 
     commonConfiguration(http);

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
@@ -148,45 +148,13 @@ public class SecurityFilterChainConfig {
     http.securityMatchers(
             matcher ->
                 matcher
-                    .requestMatchers(
-                        HttpMethod.GET,
-                        "/admin",
-                        "/admin/login",
-                        "/admin/accounts",
-                        "/admin/loans",
-                        "/admin/products")
-                    .requestMatchers(
-                        HttpMethod.POST,
-                        "/admin/accounts",
-                        "/admin/loans",
-                        "/admin/products")
-                    .requestMatchers(
-                        HttpMethod.PUT,
-                        "/admin/accounts",
-                        "/admin/loans",
-                        "/admin/products")
-                    .requestMatchers(
-                        HttpMethod.DELETE,
-                        "/admin/accounts",
-                        "/admin/loans",
-                        "/admin/products")
-                    .requestMatchers(
-                        HttpMethod.GET,
-                        "/api/admin/users",
-                        "/api/admin/users/*/accounts",
-                        "/api/admin/users/*/loans",
-                        "/api/admin/loans/*")
-                    .requestMatchers(
-                        HttpMethod.POST,
-                        "/api/admin/users/*/accounts",
-                        "/api/admin/accounts/*/withdraw",
-                        "/api/admin/accounts/*/deposit",
-                        "/api/admin/accounts/transfer",
-                        "/api/admin/accounts/*/pay",
-                        "/api/admin/users/*/loans/*",
-                        "/api/admin/loans/*/repayment")
-                    .requestMatchers(
-                        HttpMethod.DELETE, "/api/admin/accounts/*", "/api/admin/loans/*"))
+                    .requestMatchers(HttpMethod.GET, "/admin", "/admin/login", "/admin/accounts", "/admin/loans", "/admin/products")
+                    .requestMatchers(HttpMethod.POST, "/admin/accounts", "/admin/loans", "/admin/products")
+                    .requestMatchers(HttpMethod.PUT, "/admin/accounts", "/admin/loans", "/admin/products")
+                    .requestMatchers(HttpMethod.DELETE, "/admin/accounts", "/admin/loans", "/admin/products")
+                    .requestMatchers(HttpMethod.GET, "/api/admin/users", "/api/admin/users/*/accounts", "/api/admin/users/*/loans", "/api/admin/loans/*")
+                    .requestMatchers(HttpMethod.POST, "/api/admin/users/*/accounts", "/api/admin/accounts/*/withdraw", "/api/admin/accounts/*/deposit", "/api/admin/accounts/transfer", "/api/admin/accounts/*/pay", "/api/admin/users/*/loans/*", "/api/admin/loans/*/repayment")
+                    .requestMatchers(HttpMethod.DELETE, "/api/admin/accounts/*", "/api/admin/loans/*"))
         .authorizeHttpRequests(
             auth ->
                 auth

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
@@ -111,7 +111,9 @@ public class SecurityFilterChainConfig {
                         "/api/interests/{loanProductId:\\d+}",
                         "/swagger-ui/**", // TODO: Swagger 전용 필터체인으로 분리
                         "/v3/api-docs/**", // TODO: Swagger 전용 필터체인으로 분리
-                        "/swagger-resources/**" // TODO: Swagger 전용 필터체인으로 분리
+                        "/swagger-resources/**", // TODO: Swagger 전용 필터체인으로 분리
+                        "/admin/login",
+                        "/admin/**"
                         )
                     .requestMatchers(HttpMethod.POST, "/api/loans", "/api/login", "/api/users")
                     .requestMatchers(HttpMethod.DELETE, "/api/loans/products/{loanProductId:\\d+}"))
@@ -162,8 +164,15 @@ public class SecurityFilterChainConfig {
                         "/api/accounts/{accountNumber}",
                         "/api/loans/{loanLedgerId:\\d+}")
                     .requestMatchers(
-                        HttpMethod.PATCH, "/api/loans/{loanLedgerId:\\d+}/auto-deposit"))
-        .authorizeHttpRequests(request -> request.anyRequest().authenticated());
+                        HttpMethod.PATCH, "/api/loans/{loanLedgerId:\\d+}/auto-deposit")
+                    .requestMatchers("/api/admin/**"))
+        .authorizeHttpRequests(
+            request ->
+                request
+                    .requestMatchers("/api/admin/**")
+                    .hasRole("ADMIN")
+                    .anyRequest()
+                    .authenticated());
 
     http.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
     http.exceptionHandling(ex -> ex.authenticationEntryPoint(requiredAuthenticationEntryPoint));

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
@@ -26,11 +26,11 @@ import org.springframework.security.web.authentication.LoginUrlAuthenticationEnt
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.session.DisableEncodeUrlFilter;
 
-import com.fisa.bank.domains.common.config.security.resource.RequiredAuthenticationEntryPoint;
-import com.fisa.bank.domains.common.config.security.resource.UnknownEndPointFilter;
+import com.fisa.bank.domains.common.config.security.resource.AdminPageAuthFilter;
 import com.fisa.bank.domains.common.config.security.resource.LogoutCookieFilter;
 import com.fisa.bank.domains.common.config.security.resource.RefreshTokenFilter;
-import com.fisa.bank.domains.common.config.security.resource.AdminPageAuthFilter;
+import com.fisa.bank.domains.common.config.security.resource.RequiredAuthenticationEntryPoint;
+import com.fisa.bank.domains.common.config.security.resource.UnknownEndPointFilter;
 
 @Configuration
 @RequiredArgsConstructor
@@ -100,8 +100,10 @@ public class SecurityFilterChainConfig {
   @Order(2)
   // [일반 사용자용] 인증이 필요하지 않은 엔드포인트
   public SecurityFilterChain unAuthenticated(
-      HttpSecurity http, @Qualifier("unAuthenticatedFilter") AuthenticationFilter loginFilter,
-      LogoutCookieFilter logoutCookieFilter, RefreshTokenFilter refreshTokenFilter)
+      HttpSecurity http,
+      @Qualifier("unAuthenticatedFilter") AuthenticationFilter loginFilter,
+      LogoutCookieFilter logoutCookieFilter,
+      RefreshTokenFilter refreshTokenFilter)
       throws Exception {
     commonConfiguration(http);
 
@@ -148,20 +150,38 @@ public class SecurityFilterChainConfig {
     http.securityMatchers(
             matcher ->
                 matcher
-                    .requestMatchers(HttpMethod.GET, "/admin", "/admin/login", "/admin/accounts", "/admin/loans", "/admin/products")
-                    .requestMatchers(HttpMethod.POST, "/admin/accounts", "/admin/loans", "/admin/products")
-                    .requestMatchers(HttpMethod.PUT, "/admin/accounts", "/admin/loans", "/admin/products")
-                    .requestMatchers(HttpMethod.DELETE, "/admin/accounts", "/admin/loans", "/admin/products")
-                    .requestMatchers(HttpMethod.GET, "/api/admin/users", "/api/admin/users/*/accounts", "/api/admin/users/*/loans", "/api/admin/loans/*")
-                    .requestMatchers(HttpMethod.POST, "/api/admin/users/*/accounts", "/api/admin/accounts/*/withdraw", "/api/admin/accounts/*/deposit", "/api/admin/accounts/transfer", "/api/admin/accounts/*/pay", "/api/admin/users/*/loans/*", "/api/admin/loans/*/repayment")
-                    .requestMatchers(HttpMethod.DELETE, "/api/admin/accounts/*", "/api/admin/loans/*"))
+                    .requestMatchers(
+                        HttpMethod.GET,
+                        "/admin",
+                        "/admin/login",
+                        "/admin/accounts",
+                        "/admin/loans",
+                        "/admin/products")
+                    .requestMatchers(
+                        HttpMethod.POST, "/admin/accounts", "/admin/loans", "/admin/products")
+                    .requestMatchers(
+                        HttpMethod.PUT, "/admin/accounts", "/admin/loans", "/admin/products")
+                    .requestMatchers(
+                        HttpMethod.DELETE, "/admin/accounts", "/admin/loans", "/admin/products")
+                    .requestMatchers(
+                        HttpMethod.GET,
+                        "/api/admin/users",
+                        "/api/admin/users/*/accounts",
+                        "/api/admin/users/*/loans",
+                        "/api/admin/loans/*")
+                    .requestMatchers(
+                        HttpMethod.POST,
+                        "/api/admin/users/*/accounts",
+                        "/api/admin/accounts/*/withdraw",
+                        "/api/admin/accounts/*/deposit",
+                        "/api/admin/accounts/transfer",
+                        "/api/admin/accounts/*/pay",
+                        "/api/admin/users/*/loans/*",
+                        "/api/admin/loans/*/repayment")
+                    .requestMatchers(
+                        HttpMethod.DELETE, "/api/admin/accounts/*", "/api/admin/loans/*"))
         .authorizeHttpRequests(
-            auth ->
-                auth
-                    .requestMatchers("/admin/login")
-                    .permitAll()
-                    .anyRequest()
-                    .hasRole("ADMIN"));
+            auth -> auth.requestMatchers("/admin/login").permitAll().anyRequest().hasRole("ADMIN"));
 
     http.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
     http.addFilterBefore(adminPageAuthFilter, UsernamePasswordAuthenticationFilter.class);
@@ -210,8 +230,7 @@ public class SecurityFilterChainConfig {
                         "/api/loans/{loanLedgerId:\\d+}")
                     .requestMatchers(
                         HttpMethod.PATCH, "/api/loans/{loanLedgerId:\\d+}/auto-deposit"))
-        .authorizeHttpRequests(
-            request -> request.anyRequest().authenticated());
+        .authorizeHttpRequests(request -> request.anyRequest().authenticated());
 
     http.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
     http.exceptionHandling(ex -> ex.authenticationEntryPoint(requiredAuthenticationEntryPoint));

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
@@ -28,6 +28,8 @@ import org.springframework.security.web.session.DisableEncodeUrlFilter;
 
 import com.fisa.bank.domains.common.config.security.resource.RequiredAuthenticationEntryPoint;
 import com.fisa.bank.domains.common.config.security.resource.UnknownEndPointFilter;
+import com.fisa.bank.domains.common.config.security.resource.LogoutCookieFilter;
+import com.fisa.bank.domains.common.config.security.resource.RefreshTokenFilter;
 
 @Configuration
 @RequiredArgsConstructor
@@ -97,7 +99,8 @@ public class SecurityFilterChainConfig {
   @Order(2)
   // [일반 사용자용] 인증이 필요하지 않은 엔드포인트
   public SecurityFilterChain unAuthenticated(
-      HttpSecurity http, @Qualifier("unAuthenticatedFilter") AuthenticationFilter loginFilter)
+      HttpSecurity http, @Qualifier("unAuthenticatedFilter") AuthenticationFilter loginFilter,
+      LogoutCookieFilter logoutCookieFilter, RefreshTokenFilter refreshTokenFilter)
       throws Exception {
     commonConfiguration(http);
 
@@ -112,11 +115,19 @@ public class SecurityFilterChainConfig {
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/swagger-resources/**")
-                    .requestMatchers(HttpMethod.POST, "/api/loans", "/api/login", "/api/users")
+                    .requestMatchers(
+                        HttpMethod.POST,
+                        "/api/loans",
+                        "/api/login",
+                        "/api/users",
+                        "/api/token/refresh",
+                        "/api/logout")
                     .requestMatchers(HttpMethod.DELETE, "/api/loans/products/{loanProductId:\\d+}"))
         .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
 
     http.addFilterBefore(loginFilter, UsernamePasswordAuthenticationFilter.class); // login 전용 필터
+    http.addFilterBefore(refreshTokenFilter, UsernamePasswordAuthenticationFilter.class);
+    http.addFilterBefore(logoutCookieFilter, UsernamePasswordAuthenticationFilter.class);
     http.oauth2ResourceServer(AbstractHttpConfigurer::disable);
 
     return http.build();

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/jwt/JwtConst.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/jwt/JwtConst.java
@@ -10,4 +10,8 @@ public class JwtConst {
   // Token name
   public static final String ACCESS_TOKEN = "access_token";
   public static final String REFRESH_TOKEN = "refresh_token";
+
+  // Cookie name (의미가 드러나지 않는 축약 키)
+  public static final String COOKIE_ACCESS_TOKEN = "sb_at";
+  public static final String COOKIE_REFRESH_TOKEN = "sb_rt";
 }

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/jwt/UserJwtGenerator.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/jwt/UserJwtGenerator.java
@@ -34,10 +34,11 @@ public class UserJwtGenerator {
 
   public Jwt createAccessToken(Long userId, Collection<? extends GrantedAuthority> authorities) {
     ZonedDateTime now = LocalDateTime.now().atZone(KST);
+    var roles = authorities.stream().map(GrantedAuthority::getAuthority).toList();
     JwtClaimsSet claimsSet =
         JwtClaimsSet.builder()
             .claim(CLAIM_USER_ID, userId)
-            .claim(CLAIM_ROLE, authorities)
+            .claim(CLAIM_ROLE, roles)
             .issuer(CLAIM_ISSUER)
             .issuedAt(now.toInstant())
             .expiresAt(now.toInstant().plus(jwtProperties.getAccessTokenExpiration()))

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/mock/TestLoginSuccessHandler.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/mock/TestLoginSuccessHandler.java
@@ -25,6 +25,7 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fisa.bank.domains.common.config.security.jwt.UserJwtGenerator;
+import com.fisa.bank.domains.common.presentation.util.CookieUtils;
 
 /** 로그인 성공 핸들러 스프링 시큐리티에 의해, 사용자 인증이 성공하면 Authentication 객체를 Jwt 토큰으로 인코딩하여 ResponseBody에 담는다. */
 @Slf4j
@@ -49,6 +50,8 @@ public class TestLoginSuccessHandler implements AuthenticationSuccessHandler {
         Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
         String accessToken = jwtGenerator.createAccessToken(userId, authorities).getTokenValue();
         String refreshToken = jwtGenerator.createRefreshToken(userId).getTokenValue();
+
+        CookieUtils.addTokenCookies(response, accessToken, refreshToken);
 
         response.setStatus(HttpStatus.OK.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AdminPageAuthFilter.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AdminPageAuthFilter.java
@@ -31,9 +31,6 @@ public class AdminPageAuthFilter extends OncePerRequestFilter {
 
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-    if (loginMatcher.matches(request)) {
-      return true; // 로그인 페이지는 통과
-    }
     return !matcher.matches(request);
   }
 
@@ -43,10 +40,28 @@ public class AdminPageAuthFilter extends OncePerRequestFilter {
       throws ServletException, IOException {
 
     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    boolean isLoginPage = loginMatcher.matches(request);
+
+    // 인증이 안된 경우
     if (authentication == null || !authentication.isAuthenticated()) {
-      log.debug("Unauthenticated admin page access, redirecting to /admin/login");
+        // 로그인 페이지일 경우
+      if (isLoginPage) {
+        filterChain.doFilter(request, response); // 필터 통과
+        return;
+      }
+        // 로그인 페이지가 아닌 경우, 로그인 페이지로 리다이렉트
+      log.debug("인증되지 않은 관리자 페이지 접근, 리다이렉트 : /admin/login");
       response.setStatus(HttpStatus.FOUND.value());
       response.setHeader("Location", "/admin/login");
+      return;
+    }
+
+    // 인증된 경우
+      // 로그인 페이지로 접속하려고 하는 경우
+    if (isLoginPage) {
+      // 이미 인증된 상태에서 /admin/login 접근 시 메인으로 이동
+      response.setStatus(HttpStatus.FOUND.value());
+      response.setHeader("Location", "/admin");
       return;
     }
 

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AdminPageAuthFilter.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AdminPageAuthFilter.java
@@ -51,8 +51,7 @@ public class AdminPageAuthFilter extends OncePerRequestFilter {
       }
         // 로그인 페이지가 아닌 경우, 로그인 페이지로 리다이렉트
       log.debug("인증되지 않은 관리자 페이지 접근, 리다이렉트 : /admin/login");
-      response.setStatus(HttpStatus.FOUND.value());
-      response.setHeader("Location", "/admin/login");
+      response.sendRedirect("/admin/login");
       return;
     }
 
@@ -60,8 +59,7 @@ public class AdminPageAuthFilter extends OncePerRequestFilter {
       // 로그인 페이지로 접속하려고 하는 경우
     if (isLoginPage) {
       // 이미 인증된 상태에서 /admin/login 접근 시 메인으로 이동
-      response.setStatus(HttpStatus.FOUND.value());
-      response.setHeader("Location", "/admin");
+      response.sendRedirect("/admin");
       return;
     }
 

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AdminPageAuthFilter.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AdminPageAuthFilter.java
@@ -8,16 +8,12 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-/**
- * /admin 페이지(HTML) 접근 시 인증이 없으면 /admin/login 으로 리다이렉트하는 필터.
- * (API는 기존 체인에서 401 처리)
- */
+/** /admin 페이지(HTML) 접근 시 인증이 없으면 /admin/login 으로 리다이렉트하는 필터. (API는 기존 체인에서 401 처리) */
 @Slf4j
 public class AdminPageAuthFilter extends OncePerRequestFilter {
 
@@ -44,19 +40,19 @@ public class AdminPageAuthFilter extends OncePerRequestFilter {
 
     // 인증이 안된 경우
     if (authentication == null || !authentication.isAuthenticated()) {
-        // 로그인 페이지일 경우
+      // 로그인 페이지일 경우
       if (isLoginPage) {
         filterChain.doFilter(request, response); // 필터 통과
         return;
       }
-        // 로그인 페이지가 아닌 경우, 로그인 페이지로 리다이렉트
+      // 로그인 페이지가 아닌 경우, 로그인 페이지로 리다이렉트
       log.debug("인증되지 않은 관리자 페이지 접근, 리다이렉트 : /admin/login");
       response.sendRedirect("/admin/login");
       return;
     }
 
     // 인증된 경우
-      // 로그인 페이지로 접속하려고 하는 경우
+    // 로그인 페이지로 접속하려고 하는 경우
     if (isLoginPage) {
       // 이미 인증된 상태에서 /admin/login 접근 시 메인으로 이동
       response.sendRedirect("/admin");

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AdminPageAuthFilter.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AdminPageAuthFilter.java
@@ -22,13 +22,18 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class AdminPageAuthFilter extends OncePerRequestFilter {
 
   private final RequestMatcher matcher;
+  private final RequestMatcher loginMatcher;
 
-  public AdminPageAuthFilter(RequestMatcher matcher) {
+  public AdminPageAuthFilter(RequestMatcher matcher, RequestMatcher loginMatcher) {
     this.matcher = matcher;
+    this.loginMatcher = loginMatcher;
   }
 
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    if (loginMatcher.matches(request)) {
+      return true; // 로그인 페이지는 통과
+    }
     return !matcher.matches(request);
   }
 

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AdminPageAuthFilter.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AdminPageAuthFilter.java
@@ -1,0 +1,50 @@
+package com.fisa.bank.domains.common.config.security.resource;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * /admin 페이지(HTML) 접근 시 인증이 없으면 /admin/login 으로 리다이렉트하는 필터.
+ * (API는 기존 체인에서 401 처리)
+ */
+@Slf4j
+public class AdminPageAuthFilter extends OncePerRequestFilter {
+
+  private final RequestMatcher matcher;
+
+  public AdminPageAuthFilter(RequestMatcher matcher) {
+    this.matcher = matcher;
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    return !matcher.matches(request);
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    if (authentication == null || !authentication.isAuthenticated()) {
+      log.debug("Unauthenticated admin page access, redirecting to /admin/login");
+      response.setStatus(HttpStatus.FOUND.value());
+      response.setHeader("Location", "/admin/login");
+      return;
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
@@ -22,6 +22,8 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fisa.bank.domains.common.config.security.jwt.UserJwtGenerator;
+import com.fisa.bank.domains.common.config.security.resource.RefreshTokenFilter;
+import com.fisa.bank.domains.common.config.security.resource.LogoutCookieFilter;
 import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
 
 // OAuth2.0 Authorization Server 를 설정하는 Config
@@ -118,6 +120,20 @@ public class AuthorizationConfig {
     return new JwtAuthenticationProvider(jwtDecoder);
   }
 
+  @Bean
+  public RefreshTokenFilter refreshTokenFilter(
+      JwtDecoder jwtDecoder,
+      UserJwtGenerator userJwtGenerator,
+      UserAuthRepository userAuthRepository,
+      ObjectMapper objectMapper) {
+    return new RefreshTokenFilter(jwtDecoder, userJwtGenerator, userAuthRepository, objectMapper);
+  }
+
+  @Bean
+  public LogoutCookieFilter logoutCookieFilter() {
+    return new LogoutCookieFilter();
+  }
+
   /** jwt 인증필터 서블릿 필터에서 제외 */
   @Bean
   public FilterRegistrationBean<AuthenticationFilter> jwtFilterRegistrationBean(
@@ -146,4 +162,23 @@ public class AuthorizationConfig {
     registrationBean.setEnabled(false); // 서블릿 필터에서 제거
     return registrationBean;
   }
+
+  @Bean
+    public FilterRegistrationBean<LogoutCookieFilter> logoutCookieFilterFilterRegistrationBean(
+            LogoutCookieFilter logoutCookieFilter){
+      FilterRegistrationBean<LogoutCookieFilter> registrationBean =
+              new FilterRegistrationBean<>(logoutCookieFilter);
+      registrationBean.setEnabled(false); // 서블릿 필터에서 제거
+      return registrationBean;
+  }
+
+    @Bean
+    public FilterRegistrationBean<RefreshTokenFilter> logoutCookieFilterFilterRegistrationBean(
+            RefreshTokenFilter refreshTokenFilter){
+        FilterRegistrationBean<RefreshTokenFilter> registrationBean =
+                new FilterRegistrationBean<>(refreshTokenFilter);
+        registrationBean.setEnabled(false); // 서블릿 필터에서 제거
+        return registrationBean;
+    }
+
 }

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
@@ -1,8 +1,5 @@
 package com.fisa.bank.domains.common.config.security.resource;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fisa.bank.domains.common.config.security.jwt.UserJwtGenerator;
-import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -22,6 +19,10 @@ import org.springframework.security.web.authentication.AuthenticationFilter;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fisa.bank.domains.common.config.security.jwt.UserJwtGenerator;
+import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
 
 // OAuth2.0 Authorization Server 를 설정하는 Config
 @Profile({"local", "dev", "prod"})
@@ -125,7 +126,8 @@ public class AuthorizationConfig {
       ObjectMapper objectMapper) {
     RequestMatcher matcher =
         PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/api/token/refresh");
-    return new RefreshTokenFilter(jwtDecoder, userJwtGenerator, userAuthRepository, objectMapper, matcher);
+    return new RefreshTokenFilter(
+        jwtDecoder, userJwtGenerator, userAuthRepository, objectMapper, matcher);
   }
 
   @Bean
@@ -137,8 +139,10 @@ public class AuthorizationConfig {
 
   @Bean
   public AdminPageAuthFilter adminPageAuthFilter() {
-    RequestMatcher matcher = PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.GET, "/admin/**");
-    RequestMatcher loginMatcher = PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.GET, "/admin/login");
+    RequestMatcher matcher =
+        PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.GET, "/admin/**");
+    RequestMatcher loginMatcher =
+        PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.GET, "/admin/login");
     return new AdminPageAuthFilter(matcher, loginMatcher);
   }
 
@@ -190,13 +194,11 @@ public class AuthorizationConfig {
   }
 
   @Bean
-    public FilterRegistrationBean<AdminPageAuthFilter> adminPageAuthFilterFilterRegistrationBean(
-            AdminPageAuthFilter adminPageAuthFilter
-  ){
-      FilterRegistrationBean<AdminPageAuthFilter> registrationBean =
-              new FilterRegistrationBean<>(adminPageAuthFilter);
-      registrationBean.setEnabled(false);
-      return registrationBean;
+  public FilterRegistrationBean<AdminPageAuthFilter> adminPageAuthFilterFilterRegistrationBean(
+      AdminPageAuthFilter adminPageAuthFilter) {
+    FilterRegistrationBean<AdminPageAuthFilter> registrationBean =
+        new FilterRegistrationBean<>(adminPageAuthFilter);
+    registrationBean.setEnabled(false);
+    return registrationBean;
   }
-
 }

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
@@ -173,7 +173,7 @@ public class AuthorizationConfig {
   }
 
     @Bean
-    public FilterRegistrationBean<RefreshTokenFilter> logoutCookieFilterFilterRegistrationBean(
+    public FilterRegistrationBean<RefreshTokenFilter> refreshTokenFilterFilterRegistrationBean(
             RefreshTokenFilter refreshTokenFilter){
         FilterRegistrationBean<RefreshTokenFilter> registrationBean =
                 new FilterRegistrationBean<>(refreshTokenFilter);

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
@@ -1,5 +1,8 @@
 package com.fisa.bank.domains.common.config.security.resource;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fisa.bank.domains.common.config.security.jwt.UserJwtGenerator;
+import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -19,12 +22,6 @@ import org.springframework.security.web.authentication.AuthenticationFilter;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fisa.bank.domains.common.config.security.jwt.UserJwtGenerator;
-import com.fisa.bank.domains.common.config.security.resource.RefreshTokenFilter;
-import com.fisa.bank.domains.common.config.security.resource.LogoutCookieFilter;
-import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
 
 // OAuth2.0 Authorization Server 를 설정하는 Config
 @Profile({"local", "dev", "prod"})
@@ -126,12 +123,22 @@ public class AuthorizationConfig {
       UserJwtGenerator userJwtGenerator,
       UserAuthRepository userAuthRepository,
       ObjectMapper objectMapper) {
-    return new RefreshTokenFilter(jwtDecoder, userJwtGenerator, userAuthRepository, objectMapper);
+    RequestMatcher matcher =
+        PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/api/token/refresh");
+    return new RefreshTokenFilter(jwtDecoder, userJwtGenerator, userAuthRepository, objectMapper, matcher);
   }
 
   @Bean
   public LogoutCookieFilter logoutCookieFilter() {
-    return new LogoutCookieFilter();
+    RequestMatcher matcher =
+        PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, "/api/logout");
+    return new LogoutCookieFilter(matcher);
+  }
+
+  @Bean
+  public AdminPageAuthFilter adminPageAuthFilter() {
+    RequestMatcher matcher = PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.GET, "/admin/**");
+    return new AdminPageAuthFilter(matcher);
   }
 
   /** jwt 인증필터 서블릿 필터에서 제외 */
@@ -179,6 +186,16 @@ public class AuthorizationConfig {
         new FilterRegistrationBean<>(refreshTokenFilter);
     registrationBean.setEnabled(false); // 서블릿 필터에서 제거
     return registrationBean;
+  }
+
+  @Bean
+    public FilterRegistrationBean<AdminPageAuthFilter> adminPageAuthFilterFilterRegistrationBean(
+            AdminPageAuthFilter adminPageAuthFilter
+  ){
+      FilterRegistrationBean<AdminPageAuthFilter> registrationBean =
+              new FilterRegistrationBean<>(adminPageAuthFilter);
+      registrationBean.setEnabled(false);
+      return registrationBean;
   }
 
 }

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
@@ -138,7 +138,8 @@ public class AuthorizationConfig {
   @Bean
   public AdminPageAuthFilter adminPageAuthFilter() {
     RequestMatcher matcher = PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.GET, "/admin/**");
-    return new AdminPageAuthFilter(matcher);
+    RequestMatcher loginMatcher = PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.GET, "/admin/login");
+    return new AdminPageAuthFilter(matcher, loginMatcher);
   }
 
   /** jwt 인증필터 서블릿 필터에서 제외 */

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
@@ -164,21 +164,21 @@ public class AuthorizationConfig {
   }
 
   @Bean
-    public FilterRegistrationBean<LogoutCookieFilter> logoutCookieFilterFilterRegistrationBean(
-            LogoutCookieFilter logoutCookieFilter){
-      FilterRegistrationBean<LogoutCookieFilter> registrationBean =
-              new FilterRegistrationBean<>(logoutCookieFilter);
-      registrationBean.setEnabled(false); // 서블릿 필터에서 제거
-      return registrationBean;
+  public FilterRegistrationBean<LogoutCookieFilter> logoutCookieFilterRegistrationBean(
+      LogoutCookieFilter logoutCookieFilter) {
+    FilterRegistrationBean<LogoutCookieFilter> registrationBean =
+        new FilterRegistrationBean<>(logoutCookieFilter);
+    registrationBean.setEnabled(false); // 서블릿 필터에서 제거
+    return registrationBean;
   }
 
-    @Bean
-    public FilterRegistrationBean<RefreshTokenFilter> refreshTokenFilterFilterRegistrationBean(
-            RefreshTokenFilter refreshTokenFilter){
-        FilterRegistrationBean<RefreshTokenFilter> registrationBean =
-                new FilterRegistrationBean<>(refreshTokenFilter);
-        registrationBean.setEnabled(false); // 서블릿 필터에서 제거
-        return registrationBean;
-    }
+  @Bean
+  public FilterRegistrationBean<RefreshTokenFilter> refreshTokenFilterRegistrationBean(
+      RefreshTokenFilter refreshTokenFilter) {
+    FilterRegistrationBean<RefreshTokenFilter> registrationBean =
+        new FilterRegistrationBean<>(refreshTokenFilter);
+    registrationBean.setEnabled(false); // 서블릿 필터에서 제거
+    return registrationBean;
+  }
 
 }

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/CustomUserDetailsService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/CustomUserDetailsService.java
@@ -41,7 +41,8 @@ public class CustomUserDetailsService implements UserDetailsService {
       return List.of();
     }
     return switch (role) {
-      case ADMIN -> List.of(new SimpleGrantedAuthority("ROLE_ADMIN"), new SimpleGrantedAuthority("ROLE_USER"));
+      case ADMIN -> List.of(
+          new SimpleGrantedAuthority("ROLE_ADMIN"), new SimpleGrantedAuthority("ROLE_USER"));
       case USER -> List.of(new SimpleGrantedAuthority("ROLE_USER"));
     };
   }

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/CustomUserDetailsService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/CustomUserDetailsService.java
@@ -2,14 +2,17 @@ package com.fisa.bank.domains.common.config.security.resource;
 
 import lombok.RequiredArgsConstructor;
 
-import java.util.Collections;
+import java.util.Collection;
+import java.util.List;
 
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import com.fisa.bank.domains.user.persistence.entity.UserAuth;
+import com.fisa.bank.domains.user.persistence.enums.UserRole;
 import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
 
 @RequiredArgsConstructor
@@ -28,6 +31,18 @@ public class CustomUserDetailsService implements UserDetailsService {
                     new UsernameNotFoundException(
                         String.format("Username not found : %s", username)));
 
-    return new User(username, userAuth.getPassword(), Collections.emptyList());
+    Collection<SimpleGrantedAuthority> authorities = mapAuthorities(userAuth.getRole());
+
+    return new User(username, userAuth.getPassword(), authorities);
+  }
+
+  private Collection<SimpleGrantedAuthority> mapAuthorities(UserRole role) {
+    if (role == null) {
+      return List.of();
+    }
+    return switch (role) {
+      case ADMIN -> List.of(new SimpleGrantedAuthority("ROLE_ADMIN"), new SimpleGrantedAuthority("ROLE_USER"));
+      case USER -> List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    };
   }
 }

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/JwtAuthenticationConverter.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/JwtAuthenticationConverter.java
@@ -2,13 +2,12 @@ package com.fisa.bank.domains.common.config.security.resource;
 
 import static com.fisa.bank.domains.common.config.security.jwt.JwtConst.COOKIE_ACCESS_TOKEN;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationConverter;
-
-import jakarta.servlet.http.Cookie;
 
 /** 클라이언트가 보낸 Jwt 토큰을 Authentication 으로 변환해주는 역할 */
 public class JwtAuthenticationConverter implements AuthenticationConverter {

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/JwtAuthenticationConverter.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/JwtAuthenticationConverter.java
@@ -1,24 +1,46 @@
 package com.fisa.bank.domains.common.config.security.resource;
 
+import static com.fisa.bank.domains.common.config.security.jwt.JwtConst.COOKIE_ACCESS_TOKEN;
+
 import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 
+import jakarta.servlet.http.Cookie;
+
 /** 클라이언트가 보낸 Jwt 토큰을 Authentication 으로 변환해주는 역할 */
 public class JwtAuthenticationConverter implements AuthenticationConverter {
 
   @Override
   public Authentication convert(HttpServletRequest request) {
+    String token = resolveFromHeader(request);
+    if (token == null) {
+      token = resolveFromCookie(request, COOKIE_ACCESS_TOKEN);
+    }
+    if (token == null || token.isBlank()) {
+      return null; // null 반환, 필터 체인의 AuthorizationFilter에서 최종 인증/인가 여부를 판별한다.
+    }
+    return new JwtAuthentication(token);
+  }
+
+  private String resolveFromHeader(HttpServletRequest request) {
     String header = request.getHeader(HttpHeaders.AUTHORIZATION);
     if (header == null || !header.startsWith("Bearer ")) {
       return null;
     }
-    String token = header.substring(7);
-    if (token.isBlank()) {
-      return null; // null 반환, 필터 체인의 AuthorizationFilter에서 최종 인증/인가 여부를 판별한다.
+    return header.substring(7);
+  }
+
+  private String resolveFromCookie(HttpServletRequest request, String name) {
+    Cookie[] cookies = request.getCookies();
+    if (cookies == null) return null;
+    for (Cookie cookie : cookies) {
+      if (cookie != null && name.equals(cookie.getName())) {
+        return cookie.getValue();
+      }
     }
-    return new JwtAuthentication(token);
+    return null;
   }
 }

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/LoginSuccessHandler.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/LoginSuccessHandler.java
@@ -26,6 +26,7 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fisa.bank.domains.common.config.security.jwt.UserJwtGenerator;
+import com.fisa.bank.domains.common.presentation.util.CookieUtils;
 import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
 
 /** 로그인 성공 핸들러 스프링 시큐리티에 의해, 사용자 인증이 성공하면 Authentication 객체를 Jwt 토큰으로 인코딩하여 ResponseBody에 담는다. */
@@ -55,6 +56,8 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
         Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
         String accessToken = jwtGenerator.createAccessToken(userId, authorities).getTokenValue();
         String refreshToken = jwtGenerator.createRefreshToken(userId).getTokenValue();
+
+        CookieUtils.addTokenCookies(response, accessToken, refreshToken);
 
         response.setStatus(HttpStatus.OK.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/LogoutCookieFilter.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/LogoutCookieFilter.java
@@ -13,9 +13,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.fisa.bank.domains.common.presentation.util.CookieUtils;
 
-/**
- * /api/logout (POST) 요청 시 토큰 쿠키를 제거하는 필터.
- */
+/** /api/logout (POST) 요청 시 토큰 쿠키를 제거하는 필터. */
 public class LogoutCookieFilter extends OncePerRequestFilter {
 
   private final RequestMatcher matcher;

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/LogoutCookieFilter.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/LogoutCookieFilter.java
@@ -1,0 +1,34 @@
+package com.fisa.bank.domains.common.config.security.resource;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fisa.bank.domains.common.presentation.util.CookieUtils;
+
+/**
+ * /api/logout (POST) 요청 시 토큰 쿠키를 제거하는 필터.
+ */
+public class LogoutCookieFilter extends OncePerRequestFilter {
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return !"/api/logout".equals(request.getRequestURI())
+        || !"POST".equalsIgnoreCase(request.getMethod());
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    CookieUtils.clearTokenCookies(response);
+    response.setStatus(HttpStatus.OK.value());
+    response.getWriter().write("logged out");
+  }
+}

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/LogoutCookieFilter.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/LogoutCookieFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.fisa.bank.domains.common.presentation.util.CookieUtils;
@@ -17,10 +18,15 @@ import com.fisa.bank.domains.common.presentation.util.CookieUtils;
  */
 public class LogoutCookieFilter extends OncePerRequestFilter {
 
+  private final RequestMatcher matcher;
+
+  public LogoutCookieFilter(RequestMatcher matcher) {
+    this.matcher = matcher;
+  }
+
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) {
-    return !"/api/logout".equals(request.getRequestURI())
-        || !"POST".equalsIgnoreCase(request.getMethod());
+    return !matcher.matches(request);
   }
 
   @Override

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/RefreshTokenFilter.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/RefreshTokenFilter.java
@@ -34,7 +34,8 @@ import com.fisa.bank.domains.user.persistence.enums.UserRole;
 import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
 
 /**
- * Refresh Token 재발급 필터. /api/token/refresh (POST) 에서 Authorization Bearer 또는 refresh_token 쿠키로 토큰을 받아 검증 후 새 토큰을 반환한다.
+ * Refresh Token 재발급 필터. /api/token/refresh (POST) 에서 Authorization Bearer 또는 refresh_token 쿠키로 토큰을
+ * 받아 검증 후 새 토큰을 반환한다.
  */
 public class RefreshTokenFilter extends OncePerRequestFilter {
 
@@ -97,7 +98,9 @@ public class RefreshTokenFilter extends OncePerRequestFilter {
       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
       response
           .getWriter()
-          .write(objectMapper.writeValueAsString(Map.of("access_token", newAccess, "refresh_token", newRefresh)));
+          .write(
+              objectMapper.writeValueAsString(
+                  Map.of("access_token", newAccess, "refresh_token", newRefresh)));
     } catch (Exception e) {
       writeError(response, HttpStatus.UNAUTHORIZED, "Invalid refresh token");
     }
@@ -106,7 +109,8 @@ public class RefreshTokenFilter extends OncePerRequestFilter {
   private Collection<? extends GrantedAuthority> toAuthorities(UserRole role) {
     if (role == null) return List.of();
     return switch (role) {
-      case ADMIN -> List.of(new SimpleGrantedAuthority("ROLE_ADMIN"), new SimpleGrantedAuthority("ROLE_USER"));
+      case ADMIN -> List.of(
+          new SimpleGrantedAuthority("ROLE_ADMIN"), new SimpleGrantedAuthority("ROLE_USER"));
       case USER -> List.of(new SimpleGrantedAuthority("ROLE_USER"));
     };
   }

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/RefreshTokenFilter.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/RefreshTokenFilter.java
@@ -1,0 +1,133 @@
+package com.fisa.bank.domains.common.config.security.resource;
+
+import static com.fisa.bank.domains.common.config.security.jwt.JwtConst.CLAIM_USER_ID;
+import static com.fisa.bank.domains.common.config.security.jwt.JwtConst.COOKIE_REFRESH_TOKEN;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fisa.bank.domains.common.config.security.jwt.UserJwtGenerator;
+import com.fisa.bank.domains.common.presentation.util.CookieUtils;
+import com.fisa.bank.domains.user.persistence.entity.UserAuth;
+import com.fisa.bank.domains.user.persistence.entity.id.UserId;
+import com.fisa.bank.domains.user.persistence.enums.UserRole;
+import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
+
+/**
+ * Refresh Token 재발급 필터. /api/token/refresh (POST) 에서 Authorization Bearer 또는 refresh_token 쿠키로 토큰을 받아 검증 후 새 토큰을 반환한다.
+ */
+public class RefreshTokenFilter extends OncePerRequestFilter {
+
+  private final JwtDecoder jwtDecoder;
+  private final UserJwtGenerator userJwtGenerator;
+  private final UserAuthRepository userAuthRepository;
+  private final ObjectMapper objectMapper;
+
+  public RefreshTokenFilter(
+      JwtDecoder jwtDecoder,
+      UserJwtGenerator userJwtGenerator,
+      UserAuthRepository userAuthRepository,
+      ObjectMapper objectMapper) {
+    this.jwtDecoder = jwtDecoder;
+    this.userJwtGenerator = userJwtGenerator;
+    this.userAuthRepository = userAuthRepository;
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return !"/api/token/refresh".equals(request.getRequestURI())
+        || !"POST".equalsIgnoreCase(request.getMethod());
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String token = resolveToken(request, HttpHeaders.AUTHORIZATION, COOKIE_REFRESH_TOKEN);
+    if (token == null || token.isBlank()) {
+      writeError(response, HttpStatus.UNAUTHORIZED, "Refresh token not found");
+      return;
+    }
+
+    try {
+      Jwt jwt = jwtDecoder.decode(token);
+      Long userId = jwt.getClaim(CLAIM_USER_ID);
+      if (userId == null) {
+        writeError(response, HttpStatus.UNAUTHORIZED, "Invalid refresh token");
+        return;
+      }
+
+      Optional<UserAuth> userAuthOpt = userAuthRepository.findByUserId(UserId.of(userId));
+      if (userAuthOpt.isEmpty()) {
+        writeError(response, HttpStatus.UNAUTHORIZED, "User not found");
+        return;
+      }
+      UserAuth userAuth = userAuthOpt.get();
+      Collection<? extends GrantedAuthority> authorities = toAuthorities(userAuth.getRole());
+
+      String newAccess = userJwtGenerator.createAccessToken(userId, authorities).getTokenValue();
+      String newRefresh = userJwtGenerator.createRefreshToken(userId).getTokenValue();
+      CookieUtils.addTokenCookies(response, newAccess, newRefresh);
+
+      response.setStatus(HttpStatus.OK.value());
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      response
+          .getWriter()
+          .write(objectMapper.writeValueAsString(Map.of("access_token", newAccess, "refresh_token", newRefresh)));
+    } catch (Exception e) {
+      writeError(response, HttpStatus.UNAUTHORIZED, "Invalid refresh token");
+    }
+  }
+
+  private Collection<? extends GrantedAuthority> toAuthorities(UserRole role) {
+    if (role == null) return List.of();
+    return switch (role) {
+      case ADMIN -> List.of(new SimpleGrantedAuthority("ROLE_ADMIN"), new SimpleGrantedAuthority("ROLE_USER"));
+      case USER -> List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    };
+  }
+
+  private String resolveToken(HttpServletRequest request, String headerName, String cookieName) {
+    String header = request.getHeader(headerName);
+    if (header != null && header.startsWith("Bearer ")) {
+      return header.substring(7);
+    }
+    Cookie[] cookies = request.getCookies();
+    if (cookies != null) {
+      for (Cookie cookie : cookies) {
+        if (cookie != null && cookieName.equals(cookie.getName())) {
+          return cookie.getValue();
+        }
+      }
+    }
+    return null;
+  }
+
+  private void writeError(HttpServletResponse response, HttpStatus status, String message)
+      throws IOException {
+    response.setStatus(status.value());
+    response.setContentType(MediaType.TEXT_PLAIN_VALUE);
+    response.getWriter().write(message);
+  }
+}

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/RefreshTokenFilter.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/RefreshTokenFilter.java
@@ -22,6 +22,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,22 +42,24 @@ public class RefreshTokenFilter extends OncePerRequestFilter {
   private final UserJwtGenerator userJwtGenerator;
   private final UserAuthRepository userAuthRepository;
   private final ObjectMapper objectMapper;
+  private final RequestMatcher matcher;
 
   public RefreshTokenFilter(
       JwtDecoder jwtDecoder,
       UserJwtGenerator userJwtGenerator,
       UserAuthRepository userAuthRepository,
-      ObjectMapper objectMapper) {
+      ObjectMapper objectMapper,
+      RequestMatcher matcher) {
     this.jwtDecoder = jwtDecoder;
     this.userJwtGenerator = userJwtGenerator;
     this.userAuthRepository = userAuthRepository;
     this.objectMapper = objectMapper;
+    this.matcher = matcher;
   }
 
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) {
-    return !"/api/token/refresh".equals(request.getRequestURI())
-        || !"POST".equalsIgnoreCase(request.getMethod());
+    return !matcher.matches(request);
   }
 
   @Override

--- a/bank/src/main/java/com/fisa/bank/domains/common/presentation/util/CookieUtils.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/presentation/util/CookieUtils.java
@@ -1,0 +1,41 @@
+package com.fisa.bank.domains.common.presentation.util;
+
+import static com.fisa.bank.domains.common.config.security.jwt.JwtConst.COOKIE_ACCESS_TOKEN;
+import static com.fisa.bank.domains.common.config.security.jwt.JwtConst.COOKIE_REFRESH_TOKEN;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+public final class CookieUtils {
+
+  private CookieUtils() {}
+
+  public static void addTokenCookies(HttpServletResponse response, String accessToken, String refreshToken) {
+    addCookie(response, COOKIE_ACCESS_TOKEN, accessToken, true);
+    addCookie(response, COOKIE_REFRESH_TOKEN, refreshToken, true);
+  }
+
+  public static void clearTokenCookies(HttpServletResponse response) {
+    addCookie(response, COOKIE_ACCESS_TOKEN, "", true, 0);
+    addCookie(response, COOKIE_REFRESH_TOKEN, "", true, 0);
+  }
+
+  private static void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly) {
+    addCookie(response, name, value, httpOnly, -1);
+  }
+
+  private static void addCookie(
+      HttpServletResponse response, String name, String value, boolean httpOnly, int maxAge) {
+    ResponseCookie cookie =
+        ResponseCookie.from(name, value)
+            .httpOnly(httpOnly)
+            .secure(true)
+            .path("/")
+            .sameSite("Strict")
+            .maxAge(maxAge)
+            .build();
+    response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+  }
+}

--- a/bank/src/main/java/com/fisa/bank/domains/common/presentation/util/CookieUtils.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/presentation/util/CookieUtils.java
@@ -12,7 +12,8 @@ public final class CookieUtils {
 
   private CookieUtils() {}
 
-  public static void addTokenCookies(HttpServletResponse response, String accessToken, String refreshToken) {
+  public static void addTokenCookies(
+      HttpServletResponse response, String accessToken, String refreshToken) {
     addCookie(response, COOKIE_ACCESS_TOKEN, accessToken, true);
     addCookie(response, COOKIE_REFRESH_TOKEN, refreshToken, true);
   }
@@ -22,7 +23,8 @@ public final class CookieUtils {
     addCookie(response, COOKIE_REFRESH_TOKEN, "", true, 0);
   }
 
-  private static void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly) {
+  private static void addCookie(
+      HttpServletResponse response, String name, String value, boolean httpOnly) {
     addCookie(response, name, value, httpOnly, -1);
   }
 

--- a/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
+++ b/bank/src/main/java/com/fisa/bank/domains/loan/application/service/LoanService.java
@@ -121,6 +121,17 @@ public class LoanService {
   @VerifyOwner(domain = DomainType.ACCOUNT, idParam = "accountNumber")
   public LoanApplyforResponse applyForLoan(LoanApplyForRequest request, Long loanProductId) {
     UserId userId = requesterInfo.getUserId();
+    return applyForLoanInternal(userId, request, loanProductId);
+  }
+
+  @Transactional
+  public LoanApplyforResponse applyForLoanAsAdmin(
+      Long targetUserId, LoanApplyForRequest request, Long loanProductId) {
+    return applyForLoanInternal(UserId.of(targetUserId), request, loanProductId);
+  }
+
+  private LoanApplyforResponse applyForLoanInternal(
+      UserId userId, LoanApplyForRequest request, Long loanProductId) {
     // 유저 정보 추출
     User user = userReader.getUserById(userId.getValue());
     String accountNumber = request.getAccountNumber();
@@ -392,6 +403,12 @@ public class LoanService {
   @Transactional(readOnly = true)
   public List<LoanLedgerResponse> getMyLoanLedgers() {
     Long userId = requesterInfo.getUserId().getValue();
+    List<LoanLedger> loanLedgers = loanReader.findAllByUserId(userId);
+    return loanLedgers.stream().map(LoanLedgerResponse::from).toList();
+  }
+
+  @Transactional(readOnly = true)
+  public List<LoanLedgerResponse> getLoanLedgersByUser(Long userId) {
     List<LoanLedger> loanLedgers = loanReader.findAllByUserId(userId);
     return loanLedgers.stream().map(LoanLedgerResponse::from).toList();
   }

--- a/bank/src/main/java/com/fisa/bank/domains/user/persistence/entity/UserAuth.java
+++ b/bank/src/main/java/com/fisa/bank/domains/user/persistence/entity/UserAuth.java
@@ -1,14 +1,15 @@
 package com.fisa.bank.domains.user.persistence.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import com.fisa.bank.domains.user.persistence.enums.UserRole;
 
 @Entity

--- a/bank/src/main/java/com/fisa/bank/domains/user/persistence/entity/UserAuth.java
+++ b/bank/src/main/java/com/fisa/bank/domains/user/persistence/entity/UserAuth.java
@@ -3,10 +3,13 @@ package com.fisa.bank.domains.user.persistence.entity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import com.fisa.bank.domains.user.persistence.enums.UserRole;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -17,15 +20,27 @@ public class UserAuth {
   @Id private String loginId;
   private String password;
 
+  @Enumerated(EnumType.STRING)
+  private UserRole role;
+
   @OneToOne(mappedBy = "userAuth")
   private User user;
 
   public UserAuth(String loginId, String password) {
+    this(loginId, password, UserRole.USER);
+  }
+
+  public UserAuth(String loginId, String password, UserRole role) {
     this.loginId = loginId;
     this.password = password;
+    this.role = role;
   }
 
   public static UserAuth create(String loginId, String password) {
-    return new UserAuth(loginId, password);
+    return new UserAuth(loginId, password, UserRole.USER);
+  }
+
+  public static UserAuth createAdmin(String loginId, String password) {
+    return new UserAuth(loginId, password, UserRole.ADMIN);
   }
 }

--- a/bank/src/main/java/com/fisa/bank/domains/user/persistence/enums/UserRole.java
+++ b/bank/src/main/java/com/fisa/bank/domains/user/persistence/enums/UserRole.java
@@ -1,0 +1,6 @@
+package com.fisa.bank.domains.user.persistence.enums;
+
+public enum UserRole {
+  USER,
+  ADMIN
+}

--- a/bank/src/main/java/com/fisa/bank/domains/user/persistence/repository/UserAuthRepository.java
+++ b/bank/src/main/java/com/fisa/bank/domains/user/persistence/repository/UserAuthRepository.java
@@ -13,4 +13,6 @@ public interface UserAuthRepository extends JpaRepository<UserAuth, String> {
 
   @Query("SELECT ua.user.userId FROM UserAuth ua WHERE ua.loginId=:loginId")
   Optional<UserId> findUserIdByLoginId(@Param("loginId") String loginId);
+
+  Optional<UserAuth> findByUserId(UserId userId);
 }

--- a/bank/src/main/java/com/fisa/bank/domains/user/persistence/repository/UserAuthRepository.java
+++ b/bank/src/main/java/com/fisa/bank/domains/user/persistence/repository/UserAuthRepository.java
@@ -14,5 +14,6 @@ public interface UserAuthRepository extends JpaRepository<UserAuth, String> {
   @Query("SELECT ua.user.userId FROM UserAuth ua WHERE ua.loginId=:loginId")
   Optional<UserId> findUserIdByLoginId(@Param("loginId") String loginId);
 
-  Optional<UserAuth> findByUserId(UserId userId);
+  @Query("select ua from UserAuth ua where ua.user.userId = :userId")
+  Optional<UserAuth> findByUserId(@Param("userId") UserId userId);
 }

--- a/bank/src/main/java/com/fisa/bank/domains/user/persistence/repository/UserRepository.java
+++ b/bank/src/main/java/com/fisa/bank/domains/user/persistence/repository/UserRepository.java
@@ -1,8 +1,15 @@
 package com.fisa.bank.domains.user.persistence.repository;
 
+import java.util.List;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.fisa.bank.domains.user.persistence.entity.User;
 import com.fisa.bank.domains.user.persistence.entity.id.UserId;
 
-public interface UserRepository extends JpaRepository<User, UserId> {}
+public interface UserRepository extends JpaRepository<User, UserId> {
+
+  @EntityGraph(attributePaths = {"userAuth"})
+  List<User> findAll();
+}

--- a/bank/src/main/java/com/fisa/bank/domains/user/persistence/repository/UserRepository.java
+++ b/bank/src/main/java/com/fisa/bank/domains/user/persistence/repository/UserRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.fisa.bank.domains.user.persistence.entity.User;
 import com.fisa.bank.domains.user.persistence.entity.id.UserId;
@@ -11,5 +12,6 @@ import com.fisa.bank.domains.user.persistence.entity.id.UserId;
 public interface UserRepository extends JpaRepository<User, UserId> {
 
   @EntityGraph(attributePaths = {"userAuth"})
-  List<User> findAll();
+  @Query("select u from User u where u.userAuth.role <> 'ADMIN'")
+  List<User> findAllNonAdmin();
 }

--- a/bank/src/main/java/com/fisa/bank/domains/user/persistence/seed/AdminUserInitializer.java
+++ b/bank/src/main/java/com/fisa/bank/domains/user/persistence/seed/AdminUserInitializer.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -35,14 +36,17 @@ public class AdminUserInitializer implements CommandLineRunner {
   private final UserAuthRepository userAuthRepository;
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
+  private final String adminSeedPassword;
 
   public AdminUserInitializer(
       UserAuthRepository userAuthRepository,
       UserRepository userRepository,
-      @Qualifier("BcryptPasswordEncoder") PasswordEncoder passwordEncoder) {
+      @Qualifier("BcryptPasswordEncoder") PasswordEncoder passwordEncoder,
+      @Value("${admin.seed.password:Admin123!}") String adminSeedPassword) {
     this.userAuthRepository = userAuthRepository;
     this.userRepository = userRepository;
     this.passwordEncoder = passwordEncoder;
+    this.adminSeedPassword = adminSeedPassword;
   }
 
   @Override
@@ -52,8 +56,9 @@ public class AdminUserInitializer implements CommandLineRunner {
       return; // 이미 존재하면 아무 것도 하지 않음
     }
 
-    String rawPassword =
-        System.getenv().getOrDefault("ADMIN_SEED_PASSWORD", DEFAULT_PASSWORD).trim();
+    String rawPassword = adminSeedPassword == null || adminSeedPassword.isBlank()
+        ? DEFAULT_PASSWORD
+        : adminSeedPassword.trim();
     String encodedPassword = passwordEncoder.encode(rawPassword);
 
     UserAuth adminAuth = UserAuth.createAdmin(DEFAULT_LOGIN_ID, encodedPassword);

--- a/bank/src/main/java/com/fisa/bank/domains/user/persistence/seed/AdminUserInitializer.java
+++ b/bank/src/main/java/com/fisa/bank/domains/user/persistence/seed/AdminUserInitializer.java
@@ -1,0 +1,78 @@
+package com.fisa.bank.domains.user.persistence.seed;
+
+import java.math.BigInteger;
+import java.time.LocalDateTime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import com.fisa.bank.domains.user.persistence.entity.CreditRating;
+import com.fisa.bank.domains.user.persistence.entity.CustomerLevel;
+import com.fisa.bank.domains.user.persistence.entity.User;
+import com.fisa.bank.domains.user.persistence.entity.UserAuth;
+import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
+import com.fisa.bank.domains.user.persistence.repository.UserRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 애플리케이션 구동 시 관리자 계정을 보장하는 시드 러너.
+ *
+ * <p>비밀번호는 환경변수 ADMIN_SEED_PASSWORD가 우선, 없으면 기본값 Admin123! 을 사용한다.
+ */
+@Component
+@Profile({"local", "dev", "prod"})
+public class AdminUserInitializer implements CommandLineRunner {
+
+  private static final Logger log = LoggerFactory.getLogger(AdminUserInitializer.class);
+  private static final String DEFAULT_LOGIN_ID = "admin";
+  private static final String DEFAULT_PASSWORD = "Admin123!";
+
+  private final UserAuthRepository userAuthRepository;
+  private final UserRepository userRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  public AdminUserInitializer(
+      UserAuthRepository userAuthRepository,
+      UserRepository userRepository,
+      @Qualifier("BcryptPasswordEncoder") PasswordEncoder passwordEncoder) {
+    this.userAuthRepository = userAuthRepository;
+    this.userRepository = userRepository;
+    this.passwordEncoder = passwordEncoder;
+  }
+
+  @Override
+  @Transactional
+  public void run(String... args) {
+    if (userAuthRepository.existsById(DEFAULT_LOGIN_ID)) {
+      return; // 이미 존재하면 아무 것도 하지 않음
+    }
+
+    String rawPassword =
+        System.getenv().getOrDefault("ADMIN_SEED_PASSWORD", DEFAULT_PASSWORD).trim();
+    String encodedPassword = passwordEncoder.encode(rawPassword);
+
+    UserAuth adminAuth = UserAuth.createAdmin(DEFAULT_LOGIN_ID, encodedPassword);
+
+    User adminUser =
+        User.builder()
+            .name("관리자")
+            .address("Seoul")
+            .birthday(LocalDateTime.of(1990, 1, 1, 0, 0))
+            .job("ADMIN")
+            .income(BigInteger.valueOf(1_000_000_000L))
+            .creditLevel(CreditRating.AAA)
+            .customerLevel(CustomerLevel.VIP)
+            .userAuth(adminAuth)
+            .build();
+
+    // 먼저 인증 엔티티를 저장한 뒤 User를 저장
+    userAuthRepository.save(adminAuth);
+    userRepository.save(adminUser);
+    log.info("Seeded admin account with loginId='{}'", DEFAULT_LOGIN_ID);
+  }
+}

--- a/bank/src/main/java/com/fisa/bank/domains/user/persistence/seed/AdminUserInitializer.java
+++ b/bank/src/main/java/com/fisa/bank/domains/user/persistence/seed/AdminUserInitializer.java
@@ -10,6 +10,7 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.fisa.bank.domains.user.persistence.entity.CreditRating;
 import com.fisa.bank.domains.user.persistence.entity.CustomerLevel;
@@ -17,7 +18,6 @@ import com.fisa.bank.domains.user.persistence.entity.User;
 import com.fisa.bank.domains.user.persistence.entity.UserAuth;
 import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
 import com.fisa.bank.domains.user.persistence.repository.UserRepository;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 애플리케이션 구동 시 관리자 계정을 보장하는 시드 러너.

--- a/bank/src/main/resources/application.yml
+++ b/bank/src/main/resources/application.yml
@@ -20,3 +20,7 @@ server:
       cookie:
         name: BANKSESSION
   forward-headers-strategy: framework
+
+admin:
+  seed:
+    password: ${ADMIN_PASSWORD}

--- a/bank/src/main/resources/static/js/admin-common.js
+++ b/bank/src/main/resources/static/js/admin-common.js
@@ -1,0 +1,84 @@
+(function () {
+  function hasAdminRole(token) {
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+      const roles = payload.role || payload.roles || [];
+      return Array.isArray(roles) && roles.includes('ROLE_ADMIN');
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function extractPayload(json) {
+    if (!json || typeof json !== 'object') return null;
+    return json?.data?.body?.data ?? json?.data?.data ?? json?.data ?? json?.result ?? json;
+  }
+
+  function setResult(text) {
+    if (typeof resultBox !== 'undefined' && resultBox) {
+      resultBox.textContent = text;
+    }
+  }
+
+  function getToken() {
+    const saved = localStorage.getItem('admin_token');
+    if (typeof tokenInput !== 'undefined' && tokenInput) {
+      tokenInput.value = saved || '';
+    }
+    return saved;
+  }
+
+  async function callApi(method, url, body) {
+    const token = getToken();
+    if (!token) {
+      setResult('토큰이 없습니다. 로그인 후 다시 시도하세요.');
+      return null;
+    }
+    const init = {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    };
+    if (body) init.body = JSON.stringify(body);
+    const res = await fetch(url, init);
+    const text = await res.text();
+    let parsed = null;
+    try {
+      parsed = JSON.parse(text);
+      setResult(JSON.stringify(parsed, null, 2));
+    } catch (_) {
+      setResult(text);
+    }
+    return parsed ?? text;
+  }
+
+  function ensureAdminOrRedirect() {
+    const saved = localStorage.getItem('admin_token');
+    if (!saved || !hasAdminRole(saved)) {
+      localStorage.removeItem('admin_token');
+      localStorage.removeItem('admin_refresh_token');
+      window.location.href = '/admin/login';
+      return false;
+    }
+    if (typeof tokenInput !== 'undefined' && tokenInput) {
+      tokenInput.value = saved;
+    }
+    return true;
+  }
+
+  function logoutAndRedirect() {
+    localStorage.removeItem('admin_token');
+    localStorage.removeItem('admin_refresh_token');
+    window.location.href = '/admin/login';
+  }
+
+  window.adminCommon = {
+    hasAdminRole,
+    extractPayload,
+    callApi,
+    ensureAdminOrRedirect,
+    logoutAndRedirect,
+  };
+})();

--- a/bank/src/main/resources/static/js/admin-common.js
+++ b/bank/src/main/resources/static/js/admin-common.js
@@ -20,26 +20,13 @@
     }
   }
 
-  function getToken() {
-    const saved = localStorage.getItem('admin_token');
-    if (typeof tokenInput !== 'undefined' && tokenInput) {
-      tokenInput.value = saved || '';
-    }
-    return saved;
-  }
-
   async function callApi(method, url, body) {
-    const token = getToken();
-    if (!token) {
-      setResult('토큰이 없습니다. 로그인 후 다시 시도하세요.');
-      return null;
-    }
     const init = {
       method,
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
       },
+      credentials: 'include',
     };
     if (body) init.body = JSON.stringify(body);
     const res = await fetch(url, init);
@@ -55,23 +42,14 @@
   }
 
   function ensureAdminOrRedirect() {
-    const saved = localStorage.getItem('admin_token');
-    if (!saved || !hasAdminRole(saved)) {
-      localStorage.removeItem('admin_token');
-      localStorage.removeItem('admin_refresh_token');
-      window.location.href = '/admin/login';
-      return false;
-    }
-    if (typeof tokenInput !== 'undefined' && tokenInput) {
-      tokenInput.value = saved;
-    }
-    return true;
+    // 클라이언트에서 로그인 여부를 판별하지 않고, 호출 시 401이면 서버 응답에 따름
+    return Promise.resolve(true);
   }
 
   function logoutAndRedirect() {
-    localStorage.removeItem('admin_token');
-    localStorage.removeItem('admin_refresh_token');
-    window.location.href = '/admin/login';
+    fetch('/api/logout', { method: 'POST', credentials: 'include' }).finally(() => {
+      window.location.href = '/admin/login';
+    });
   }
 
   window.adminCommon = {

--- a/bank/src/main/resources/templates/admin/accounts.html
+++ b/bank/src/main/resources/templates/admin/accounts.html
@@ -71,6 +71,11 @@
     </div>
 
     <div class="card">
+      <h3>계좌 목록</h3>
+      <div id="account-pills" class="pill-row"></div>
+    </div>
+
+    <div class="card">
       <h3>입금 / 출금</h3>
       <label>계좌 선택</label>
       <select id="txn-account-select"></select>

--- a/bank/src/main/resources/templates/admin/accounts.html
+++ b/bank/src/main/resources/templates/admin/accounts.html
@@ -124,7 +124,10 @@
         window.adminCommon;
     const state = { accounts: [], users: [], selectedUserId: null };
 
-    if (!ensureAdminOrRedirect()) return;
+    document.addEventListener('DOMContentLoaded', () => {
+      fetchUsers();
+      renderAccountOptions();
+    });
 
     function renderAccountOptions() {
       const selects = ['txn-account-select','from-account-select','pay-account-select'];
@@ -205,9 +208,6 @@
       renderUsers();
       fetchAccounts();
     }
-
-    // 초기 로드 시 사용자 목록 불러오기
-    document.addEventListener('DOMContentLoaded', fetchUsers);
 
     async function deposit() {
       const account = document.getElementById('txn-account-select').value;

--- a/bank/src/main/resources/templates/admin/accounts.html
+++ b/bank/src/main/resources/templates/admin/accounts.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>계좌 관리 | 관리자</title>
+  <style>
+    :root {
+      --bg: #f4f9ff;
+      --panel: rgba(255, 255, 255, 0.9);
+      --accent: #0d6efd;
+      --accent-2: #00b7ff;
+      --text: #0a2540;
+      --muted: #425466;
+      --border: #d8e3f2;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: 'Pretendard', 'Segoe UI', sans-serif; background: radial-gradient(circle at 20% 20%, rgba(0, 183, 255, 0.12), transparent 28%), radial-gradient(circle at 80% 0%, rgba(13, 110, 253, 0.12), transparent 30%), linear-gradient(180deg, #f7fbff, #eef5ff 45%, #f7fbff 80%); color: var(--text); }
+    header { position: relative; overflow: hidden; padding: 26px; background: linear-gradient(135deg, #e5f1ff, #f9fdff); border-bottom: 1px solid var(--border); }
+    header:after { content:''; position:absolute; right:-120px; top:-140px; width:320px; height:320px; border-radius:50%; background: radial-gradient(circle, rgba(0,183,255,0.22), transparent 60%); filter: blur(10px); }
+    h1 { margin: 0 0 6px; letter-spacing:-0.02em; }
+    p { margin: 0; color: var(--muted); }
+    .grid { display: grid; gap: 18px; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); padding: 22px; }
+    .card { position:relative; overflow:hidden; background: var(--panel); border: 1px solid var(--border); border-radius: 16px; padding: 16px; box-shadow: 0 16px 36px rgba(12, 70, 156, 0.08); backdrop-filter: blur(4px); }
+    .card:before { content:''; position:absolute; right:-40px; bottom:-50px; width:150px; height:150px; background: radial-gradient(circle, rgba(0,183,255,0.16), transparent 60%); }
+    label { display: block; font-size: 13px; color: var(--muted); margin: 8px 0 4px; }
+    input, select { width: 100%; padding: 11px; border-radius: 12px; border: 1px solid var(--border); font-size: 14px; background:#fff; box-shadow: inset 0 1px 2px rgba(0,0,0,0.03); }
+    button { margin-top: 12px; width: 100%; padding: 11px; background: linear-gradient(135deg, var(--accent), var(--accent-2)); color: #fff; border: none; border-radius: 12px; font-weight: 800; cursor: pointer; box-shadow: 0 12px 26px rgba(13,110,253,0.22); letter-spacing:-0.01em; }
+    .ghost { background:#fff; color: var(--text); border:1px solid var(--border); box-shadow:none; }
+    .row { display: flex; gap: 10px; }
+    .pill-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; }
+    .pill { padding: 6px 10px; border-radius: 18px; border: 1px solid var(--border); background: #f8fbff; }
+    .result { background: #0f172a; color: #e5e7eb; border-radius: 12px; padding: 14px; margin: 20px; min-height: 160px; white-space: pre-wrap; font-family: 'JetBrains Mono','SFMono-Regular', monospace; box-shadow: 0 16px 32px rgba(0,0,0,0.08); }
+    .link-back { color: var(--accent); text-decoration: none; font-weight: 800; }
+    .user-list { display:grid; grid-template-columns: repeat(auto-fit,minmax(240px,1fr)); gap:10px; margin-top:10px; }
+    .user-card { padding: 12px; border:1px solid var(--border); border-radius:12px; background:#fff; cursor:pointer; transition: border-color 120ms ease, box-shadow 120ms ease; }
+    .user-card:hover { border-color: var(--accent); box-shadow: 0 8px 20px rgba(13,110,253,0.12); }
+    .user-card.active { border-color: var(--accent); box-shadow: 0 8px 20px rgba(13,110,253,0.16); background: #e7f2ff; }
+    .user-name { font-weight:700; }
+    .user-sub { color: var(--muted); font-size: 13px; margin-top:4px; }
+  </style>
+</head>
+<body>
+  <header>
+    <a class="link-back" href="/admin">← 관리자 홈</a>
+    <h1>계좌 관리</h1>
+    <p>ADMIN 로그인 후 이동한 페이지입니다. 토큰이 없으면 홈으로 이동합니다.</p>
+    <div style="max-width:520px; margin-top: 10px;">
+      <label for="token">Access Token (읽기 전용)</label>
+      <input id="token" type="text" readonly />
+      <button style="margin-top:10px; padding:10px; border-radius:10px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;" onclick="logout()">로그아웃</button>
+    </div>
+  </header>
+
+  <div class="grid">
+    <div class="card">
+      <h3>계좌 생성</h3>
+      <label>선택된 사용자</label>
+      <div id="selected-user" style="padding:8px 10px; border:1px solid var(--border); border-radius:10px; background:#fff; min-height:36px;">사용자를 선택하세요.</div>
+      <label style="display:flex; align-items:center; gap:8px; margin-top:12px;">
+        <input id="income" type="checkbox" style="width:auto;" /> 급여 계좌로 생성
+      </label>
+      <button onclick="createAccount()">계좌 생성</button>
+    </div>
+
+    <div class="card">
+      <h3>사용자 선택</h3>
+      <div class="user-list" id="user-list"></div>
+      <button class="ghost" onclick="fetchUsers()">목록 새로고침</button>
+      <div class="hint">사용자를 클릭하면 해당 사용자의 계좌가 로드됩니다.</div>
+    </div>
+
+    <div class="card">
+      <h3>입금 / 출금</h3>
+      <label>계좌 선택</label>
+      <select id="txn-account-select"></select>
+      <label>금액</label>
+      <input id="txn-amount" type="number" />
+      <div class="row">
+        <button onclick="deposit()">입금</button>
+        <button onclick="withdraw()">출금</button>
+      </div>
+    </div>
+
+    <div class="card">
+      <h3>송금</h3>
+      <label>보내는 계좌</label>
+      <select id="from-account-select"></select>
+      <label>받는 계좌 번호</label>
+      <input id="to-account" type="text" />
+      <label>받는 은행 코드</label>
+      <input id="to-bank" type="text" value="001" />
+      <label>금액</label>
+      <input id="transfer-amount" type="number" />
+      <button onclick="transfer()">송금</button>
+    </div>
+
+    <div class="card">
+      <h3>카드 결제</h3>
+      <label>결제 계좌</label>
+      <select id="pay-account-select"></select>
+      <label>금액</label>
+      <input id="pay-amount" type="number" />
+      <label>가맹점</label>
+      <input id="pay-store" type="text" placeholder="STORE" />
+      <label>카테고리</label>
+      <input id="pay-category" type="text" placeholder="FOOD" />
+      <button onclick="pay()">결제 처리</button>
+    </div>
+  </div>
+
+  <div class="result" id="result">응답이 여기에 표시됩니다.</div>
+
+  <script>
+    const resultBox = document.getElementById('result');
+    const tokenInput = document.getElementById('token');
+    const state = { accounts: [], users: [], selectedUserId: null };
+
+    const saved = localStorage.getItem('admin_token');
+    if (!saved || !hasAdminRole(saved)) {
+      alert('ADMIN 권한이 필요합니다.');
+      localStorage.removeItem('admin_token');
+      localStorage.removeItem('admin_refresh_token');
+      location.href = '/admin/login';
+    } else {
+      tokenInput.value = saved;
+    }
+
+    function logout() {
+      localStorage.removeItem('admin_token');
+      localStorage.removeItem('admin_refresh_token');
+      location.href = '/admin/login';
+    }
+
+    function extractPayload(json) {
+      if (!json || typeof json !== 'object') return null;
+      return json?.data?.body?.data ?? json?.data?.data ?? json?.data ?? json?.result ?? json;
+    }
+
+    async function callApi(method, url, body) {
+      const token = tokenInput.value.trim();
+      if (!token) { resultBox.textContent = '토큰을 입력하세요.'; return null; }
+      const init = { method, headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` } };
+      if (body) init.body = JSON.stringify(body);
+      const res = await fetch(url, init);
+      const text = await res.text();
+      let parsed = null;
+      try { parsed = JSON.parse(text); resultBox.textContent = JSON.stringify(parsed, null, 2); }
+      catch (_) { resultBox.textContent = text; }
+      return parsed ?? text;
+    }
+
+    function hasAdminRole(token) {
+      try {
+        const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+        const roles = payload.role || payload.roles || [];
+        return Array.isArray(roles) && roles.includes('ROLE_ADMIN');
+      } catch (_) {
+        return false;
+      }
+    }
+
+    function renderAccountOptions() {
+      const selects = ['txn-account-select','from-account-select','pay-account-select'];
+      selects.forEach(id => {
+        const sel = document.getElementById(id);
+        sel.innerHTML = '';
+        const ph = document.createElement('option'); ph.value = ''; ph.textContent = '계좌 선택'; sel.appendChild(ph);
+        state.accounts.forEach(a => {
+          const opt = document.createElement('option');
+          const num = a.accountNumber ?? a.account_number;
+          opt.value = num;
+          opt.textContent = `${num} (잔액: ${a.balance ?? '-'})`;
+          sel.appendChild(opt);
+        });
+      });
+      const pills = document.getElementById('account-pills');
+      pills.innerHTML = '';
+      state.accounts.forEach(a => {
+        const pill = document.createElement('div'); pill.className = 'pill'; pill.textContent = `${a.accountNumber ?? a.account_number} · 잔액 ${a.balance ?? '-'}`; pills.appendChild(pill);
+      });
+    }
+
+    function renderUsers() {
+      const wrap = document.getElementById('user-list');
+      wrap.innerHTML = '';
+      state.users.forEach(u => {
+        const card = document.createElement('div');
+        card.className = 'user-card';
+        if (state.selectedUserId === u.userId) card.classList.add('active');
+        card.onclick = () => selectUser(u.userId);
+
+        const name = document.createElement('div');
+        name.className = 'user-name';
+        name.textContent = `${u.name} (#${u.userId})`;
+        const sub = document.createElement('div');
+        sub.className = 'user-sub';
+        sub.textContent = `loginId: ${u.loginId}`;
+
+        card.appendChild(name);
+        card.appendChild(sub);
+        wrap.appendChild(card);
+      });
+      const sel = document.getElementById('selected-user');
+      if (state.selectedUserId) {
+        const user = state.users.find(u => u.userId === state.selectedUserId);
+        sel.textContent = user ? `${user.name} (#${user.userId}) / ${user.loginId}` : '선택됨';
+      } else {
+        sel.textContent = '사용자를 선택하세요.';
+      }
+    }
+
+    async function createAccount() {
+      const userId = state.selectedUserId;
+      if (!userId) return alert('사용자를 먼저 선택하세요.');
+      const income = document.getElementById('income').checked;
+      await callApi('POST', `/api/admin/users/${userId}/accounts?income=${income}`, null);
+    }
+
+    async function fetchAccounts() {
+      const userId = state.selectedUserId;
+      if (!userId) return alert('사용자를 먼저 선택하세요.');
+      const json = await callApi('GET', `/api/admin/users/${userId}/accounts`);
+      const payload = extractPayload(json);
+      if (Array.isArray(payload)) { state.accounts = payload; renderAccountOptions(); }
+    }
+
+    async function fetchUsers() {
+      const json = await callApi('GET', '/api/admin/users');
+      const payload = extractPayload(json);
+      if (Array.isArray(payload)) {
+        state.users = payload;
+        renderUsers();
+      }
+    }
+
+    function selectUser(userId) {
+      state.selectedUserId = userId;
+      renderUsers();
+      fetchAccounts();
+    }
+
+    // 초기 로드 시 사용자 목록 불러오기
+    document.addEventListener('DOMContentLoaded', fetchUsers);
+
+    async function deposit() {
+      const account = document.getElementById('txn-account-select').value;
+      const amount = Number(document.getElementById('txn-amount').value);
+      if (!account) return resultBox.textContent = '계좌를 선택하세요.';
+      await callApi('POST', `/api/admin/accounts/${account}/deposit`, { amount });
+    }
+
+    async function withdraw() {
+      const account = document.getElementById('txn-account-select').value;
+      const amount = Number(document.getElementById('txn-amount').value);
+      if (!account) return resultBox.textContent = '계좌를 선택하세요.';
+      await callApi('POST', `/api/admin/accounts/${account}/withdraw`, { amount });
+    }
+
+    async function transfer() {
+      const fromAccountNumber = document.getElementById('from-account-select').value;
+      const toAccountNumber = document.getElementById('to-account').value;
+      const toBankCode = document.getElementById('to-bank').value;
+      const amount = Number(document.getElementById('transfer-amount').value);
+      if (!fromAccountNumber) return resultBox.textContent = '보내는 계좌를 선택하세요.';
+      await callApi('POST', '/api/admin/accounts/transfer', { fromAccountNumber, toAccountNumber, toBankCode, amount });
+    }
+
+    async function pay() {
+      const accountNumber = document.getElementById('pay-account-select').value;
+      const amount = Number(document.getElementById('pay-amount').value);
+      const storeName = document.getElementById('pay-store').value;
+      const category = document.getElementById('pay-category').value;
+      if (!accountNumber) return resultBox.textContent = '결제 계좌를 선택하세요.';
+      await callApi('POST', `/api/admin/accounts/${accountNumber}/pay`, { amount, storeName, category });
+    }
+
+    renderAccountOptions();
+  </script>
+</body>
+</html>

--- a/bank/src/main/resources/templates/admin/accounts.html
+++ b/bank/src/main/resources/templates/admin/accounts.html
@@ -48,7 +48,7 @@
     <div style="max-width:520px; margin-top: 10px;">
       <label for="token">Access Token (읽기 전용)</label>
       <input id="token" type="text" readonly />
-      <button style="margin-top:10px; padding:10px; border-radius:10px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;" onclick="logout()">로그아웃</button>
+      <button style="margin-top:10px; padding:10px; border-radius:10px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;" onclick="logoutAndRedirect()">로그아웃</button>
     </div>
   </header>
 
@@ -116,54 +116,15 @@
 
   <div class="result" id="result">응답이 여기에 표시됩니다.</div>
 
+  <script src="/js/admin-common.js"></script>
   <script>
     const resultBox = document.getElementById('result');
     const tokenInput = document.getElementById('token');
+    const { callApi, extractPayload, hasAdminRole, ensureAdminOrRedirect, logoutAndRedirect } =
+        window.adminCommon;
     const state = { accounts: [], users: [], selectedUserId: null };
 
-    const saved = localStorage.getItem('admin_token');
-    if (!saved || !hasAdminRole(saved)) {
-      alert('ADMIN 권한이 필요합니다.');
-      localStorage.removeItem('admin_token');
-      localStorage.removeItem('admin_refresh_token');
-      location.href = '/admin/login';
-    } else {
-      tokenInput.value = saved;
-    }
-
-    function logout() {
-      localStorage.removeItem('admin_token');
-      localStorage.removeItem('admin_refresh_token');
-      location.href = '/admin/login';
-    }
-
-    function extractPayload(json) {
-      if (!json || typeof json !== 'object') return null;
-      return json?.data?.body?.data ?? json?.data?.data ?? json?.data ?? json?.result ?? json;
-    }
-
-    async function callApi(method, url, body) {
-      const token = tokenInput.value.trim();
-      if (!token) { resultBox.textContent = '토큰을 입력하세요.'; return null; }
-      const init = { method, headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` } };
-      if (body) init.body = JSON.stringify(body);
-      const res = await fetch(url, init);
-      const text = await res.text();
-      let parsed = null;
-      try { parsed = JSON.parse(text); resultBox.textContent = JSON.stringify(parsed, null, 2); }
-      catch (_) { resultBox.textContent = text; }
-      return parsed ?? text;
-    }
-
-    function hasAdminRole(token) {
-      try {
-        const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
-        const roles = payload.role || payload.roles || [];
-        return Array.isArray(roles) && roles.includes('ROLE_ADMIN');
-      } catch (_) {
-        return false;
-      }
-    }
+    if (!ensureAdminOrRedirect()) return;
 
     function renderAccountOptions() {
       const selects = ['txn-account-select','from-account-select','pay-account-select'];

--- a/bank/src/main/resources/templates/admin/admin.html
+++ b/bank/src/main/resources/templates/admin/admin.html
@@ -1,0 +1,429 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin Console</title>
+  <style>
+    :root {
+      --bg: #0f172a;
+      --panel: #111827;
+      --accent: #06b6d4;
+      --text: #e5e7eb;
+      --muted: #9ca3af;
+      --border: #1f2937;
+    }
+    body {
+      margin: 0;
+      font-family: "JetBrains Mono", "Segoe UI", sans-serif;
+      background: radial-gradient(circle at 20% 20%, rgba(6, 182, 212, 0.08), transparent 35%),
+        radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.08), transparent 30%),
+        var(--bg);
+      color: var(--text);
+    }
+    header {
+      padding: 32px;
+      border-bottom: 1px solid var(--border);
+      background: linear-gradient(90deg, rgba(6, 182, 212, 0.14), transparent 60%);
+    }
+    h1 {
+      margin: 0 0 8px;
+      letter-spacing: 0.5px;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+      gap: 16px;
+      padding: 24px;
+    }
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 16px;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+    }
+    .card h2 {
+      margin-top: 0;
+      margin-bottom: 8px;
+      font-size: 18px;
+    }
+    label {
+      display: block;
+      font-size: 13px;
+      color: var(--muted);
+      margin: 8px 0 4px;
+    }
+    input, select, textarea {
+      width: 100%;
+      padding: 10px;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      background: #0b1220;
+      color: var(--text);
+      font-size: 14px;
+      box-sizing: border-box;
+    }
+    button {
+      margin-top: 12px;
+      width: 100%;
+      padding: 10px;
+      background: var(--accent);
+      color: #0b1220;
+      border: none;
+      border-radius: 8px;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    button:hover { opacity: 0.92; }
+    .result {
+      grid-column: 1 / -1;
+      background: #0b1220;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 16px;
+      margin: 0 24px 24px;
+      min-height: 180px;
+      white-space: pre-wrap;
+      font-family: "JetBrains Mono", "SFMono-Regular", monospace;
+    }
+    .pill-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; }
+    .pill { padding: 6px 10px; border: 1px solid var(--border); border-radius: 20px; background: #0b1220; }
+    .hint { color: var(--muted); font-size: 12px; margin-top: 4px; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>관리자 콘솔</h1>
+    <p style="color: var(--muted); margin: 0;">Bearer 토큰을 입력 후 버튼만 클릭하세요. ADMIN 토큰 필수.</p>
+    <div style="margin-top: 12px; max-width: 520px;">
+      <label for="token">Access Token</label>
+      <input id="token" type="text" placeholder="eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..." />
+    </div>
+  </header>
+
+  <div class="grid">
+    <div class="card">
+      <h2>계좌 생성</h2>
+      <label>사용자 ID</label>
+      <input id="acct-user-id" type="number" />
+      <label><input id="income" type="checkbox" /> 급여 계좌로 생성</label>
+      <button onclick="createAccount()">계좌 생성</button>
+    </div>
+
+    <div class="card">
+      <h2>사용자 계좌 불러오기</h2>
+      <label>사용자 ID</label>
+      <input id="acct-list-user" type="number" />
+      <button onclick="fetchAccounts()">계좌 목록 불러오기</button>
+      <div class="hint">불러오면 아래 모든 선택기(입금/송금/대출)에 자동 반영됩니다.</div>
+      <div id="account-pills" class="pill-row"></div>
+    </div>
+
+    <div class="card">
+      <h2>대출 상품 선택</h2>
+      <label>대출 상품</label>
+      <select id="loan-product-select"></select>
+      <button onclick="loadProducts()">상품 목록 새로고침</button>
+      <div id="product-list" class="pill-row" style="margin-top: 10px;"></div>
+    </div>
+
+    <div class="card">
+      <h2>입금 / 출금</h2>
+      <label>계좌 선택</label>
+      <select id="txn-account-select"></select>
+      <label>금액</label>
+      <input id="txn-amount" type="number" />
+      <div style="display:flex; gap:8px;">
+        <button style="flex:1" onclick="deposit()">입금</button>
+        <button style="flex:1" onclick="withdraw()">출금</button>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>송금</h2>
+      <label>보내는 계좌</label>
+      <select id="from-account-select"></select>
+      <label>받는 계좌</label>
+      <input id="to-account" type="text" />
+      <label>받는 은행 코드</label>
+      <input id="to-bank" type="text" value="001" />
+      <label>금액</label>
+      <input id="transfer-amount" type="number" />
+      <button onclick="transfer()">송금</button>
+    </div>
+
+    <div class="card">
+      <h2>카드 결제</h2>
+      <label>결제 계좌</label>
+      <select id="pay-account-select"></select>
+      <label>금액</label>
+      <input id="pay-amount" type="number" />
+      <label>가맹점</label>
+      <input id="pay-store" type="text" placeholder="STORE" />
+      <label>카테고리</label>
+      <input id="pay-category" type="text" placeholder="FOOD" />
+      <button onclick="pay()">결제 처리</button>
+    </div>
+
+    <div class="card">
+      <h2>대출 가입</h2>
+      <label>사용자 ID (계좌와 매칭)</label>
+      <input id="loan-user" type="number" />
+      <label>대출 상품</label>
+      <select id="loan-product-select-join"></select>
+      <label>대출 계좌</label>
+      <select id="loan-account-select"></select>
+      <label>원금</label>
+      <input id="loan-principal" type="number" />
+      <label>금리 유형</label>
+      <select id="loan-interest">
+        <option value="FIXED">FIXED</option>
+        <option value="VARIABLE">VARIABLE</option>
+      </select>
+      <label>상환 방법</label>
+      <select id="loan-repayment">
+        <option value="EQUAL_INSTALLMENT">EQUAL_INSTALLMENT</option>
+        <option value="EQUAL_PRINCIPAL">EQUAL_PRINCIPAL</option>
+        <option value="BULLET">BULLET</option>
+      </select>
+      <label>상환 기간(년)</label>
+      <input id="loan-term" type="number" />
+      <label>자동 예치 여부</label>
+      <select id="loan-auto">
+        <option value="true">true</option>
+        <option value="false">false</option>
+      </select>
+      <button onclick="applyLoan()">대출 가입</button>
+    </div>
+
+    <div class="card">
+      <h2>대출 상환 / 해지</h2>
+      <label>대출 원장 ID</label>
+      <input id="ledger-id" type="number" />
+      <label>상환 금액</label>
+      <input id="repay-amount" type="number" />
+      <div style="display:flex; gap:8px;">
+        <button style="flex:1" onclick="repayLoan()">상환</button>
+        <button style="flex:1" onclick="cancelLoan()">해지</button>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>사용자 대출 목록</h2>
+      <label>사용자 ID</label>
+      <input id="loan-list-user" type="number" />
+      <button onclick="fetchLoans()">조회</button>
+    </div>
+  </div>
+
+  <div class="result" id="result">결과가 여기에 표시됩니다.</div>
+
+  <script>
+    const resultBox = document.getElementById('result');
+    const tokenInput = document.getElementById('token');
+    const state = { products: [], accounts: [] };
+
+    document.addEventListener('DOMContentLoaded', () => {
+      loadProducts();
+      renderAccountOptions();
+    });
+
+    function extractPayload(json) {
+      if (!json || typeof json !== 'object') return null;
+      return json?.data?.body?.data ?? json?.data?.data ?? json?.data ?? json?.result ?? json;
+    }
+
+    async function callApi(method, url, body) {
+      const token = tokenInput.value.trim();
+      if (!token) {
+        resultBox.textContent = '토큰을 입력하세요.';
+        return null;
+      }
+      const init = {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      };
+      if (body) {
+        init.body = JSON.stringify(body);
+      }
+      const res = await fetch(url, init);
+      const text = await res.text();
+      let parsed = null;
+      try {
+        parsed = JSON.parse(text);
+        resultBox.textContent = JSON.stringify(parsed, null, 2);
+      } catch (_) {
+        resultBox.textContent = text;
+      }
+      return parsed ?? text;
+    }
+
+    async function loadProducts() {
+      try {
+        const res = await fetch('/api/loans/products?size=50');
+        const json = await res.json();
+        const payload = extractPayload(json);
+        state.products = payload?.content ?? payload ?? [];
+        renderProducts();
+      } catch (e) {
+        resultBox.textContent = '대출 상품 조회 실패: ' + e;
+      }
+    }
+
+    function renderProducts() {
+      const select = document.getElementById('loan-product-select');
+      const selectJoin = document.getElementById('loan-product-select-join');
+      const list = document.getElementById('product-list');
+      select.innerHTML = '';
+      selectJoin.innerHTML = '';
+      list.innerHTML = '';
+      state.products.forEach((p) => {
+        const option = document.createElement('option');
+        option.value = p.loanProductId ?? p.id ?? p.loanProductId;
+        option.textContent = `${p.name ?? '상품'} (#${option.value})`;
+        select.appendChild(option.cloneNode(true));
+        selectJoin.appendChild(option);
+
+        const pill = document.createElement('div');
+        pill.className = 'pill';
+        pill.textContent = `${p.name ?? '상품'} | type: ${p.type ?? ''}`;
+        list.appendChild(pill);
+      });
+    }
+
+    function renderAccountOptions() {
+      const targets = [
+        'txn-account-select',
+        'from-account-select',
+        'pay-account-select',
+        'loan-account-select',
+      ];
+      targets.forEach((id) => {
+        const sel = document.getElementById(id);
+        if (!sel) return;
+        sel.innerHTML = '';
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = '계좌를 선택하세요';
+        sel.appendChild(placeholder);
+        state.accounts.forEach((acct) => {
+          const opt = document.createElement('option');
+          const num = acct.accountNumber ?? acct.account_number ?? acct.accountId;
+          opt.value = num;
+          opt.textContent = `${num} (잔액: ${acct.balance ?? '-'})`;
+          sel.appendChild(opt);
+        });
+      });
+
+      const pillWrap = document.getElementById('account-pills');
+      pillWrap.innerHTML = '';
+      state.accounts.forEach((acct) => {
+        const pill = document.createElement('div');
+        pill.className = 'pill';
+        pill.textContent = `${acct.accountNumber ?? acct.account_number} | 잔액 ${acct.balance ?? '-'}`;
+        pillWrap.appendChild(pill);
+      });
+    }
+
+    async function createAccount() {
+      const userId = document.getElementById('acct-user-id').value;
+      const income = document.getElementById('income').checked;
+      await callApi('POST', `/api/admin/users/${userId}/accounts?income=${income}`, null);
+    }
+
+    async function fetchAccounts() {
+      const userId = document.getElementById('acct-list-user').value;
+      const json = await callApi('GET', `/api/admin/users/${userId}/accounts`);
+      const payload = extractPayload(json);
+      if (Array.isArray(payload)) {
+        state.accounts = payload;
+        renderAccountOptions();
+      }
+    }
+
+    async function deposit() {
+      const account = document.getElementById('txn-account-select').value;
+      const amount = Number(document.getElementById('txn-amount').value);
+      if (!account) return (resultBox.textContent = '계좌를 선택하세요.');
+      await callApi('POST', `/api/admin/accounts/${account}/deposit`, { amount });
+    }
+
+    async function withdraw() {
+      const account = document.getElementById('txn-account-select').value;
+      const amount = Number(document.getElementById('txn-amount').value);
+      if (!account) return (resultBox.textContent = '계좌를 선택하세요.');
+      await callApi('POST', `/api/admin/accounts/${account}/withdraw`, { amount });
+    }
+
+    async function transfer() {
+      const fromAccountNumber = document.getElementById('from-account-select').value;
+      const toAccountNumber = document.getElementById('to-account').value;
+      const toBankCode = document.getElementById('to-bank').value;
+      const amount = Number(document.getElementById('transfer-amount').value);
+      if (!fromAccountNumber) return (resultBox.textContent = '보내는 계좌를 선택하세요.');
+      await callApi('POST', '/api/admin/accounts/transfer', {
+        fromAccountNumber,
+        toAccountNumber,
+        toBankCode,
+        amount,
+      });
+    }
+
+    async function pay() {
+      const accountNumber = document.getElementById('pay-account-select').value;
+      const amount = Number(document.getElementById('pay-amount').value);
+      const storeName = document.getElementById('pay-store').value;
+      const category = document.getElementById('pay-category').value;
+      if (!accountNumber) return (resultBox.textContent = '결제 계좌를 선택하세요.');
+      await callApi('POST', `/api/admin/accounts/${accountNumber}/pay`, {
+        amount,
+        storeName,
+        category,
+      });
+    }
+
+    async function applyLoan() {
+      const userId = document.getElementById('loan-user').value;
+      const loanProductId = document.getElementById('loan-product-select-join').value;
+      const accountNumber = document.getElementById('loan-account-select').value;
+      const principal = Number(document.getElementById('loan-principal').value);
+      const interestType = document.getElementById('loan-interest').value;
+      const repaymentType = document.getElementById('loan-repayment').value;
+      const term = Number(document.getElementById('loan-term').value);
+      const autoDepositEnabled = document.getElementById('loan-auto').value === 'true';
+      if (!loanProductId || !accountNumber) {
+        resultBox.textContent = '대출 상품과 계좌를 선택하세요.';
+        return;
+      }
+      await callApi('POST', `/api/admin/users/${userId}/loans/${loanProductId}`, {
+        principal,
+        interestType,
+        repaymentType,
+        term,
+        accountNumber,
+        autoDepositEnabled,
+      });
+    }
+
+    async function repayLoan() {
+      const loanLedgerId = document.getElementById('ledger-id').value;
+      const amount = Number(document.getElementById('repay-amount').value);
+      await callApi('POST', `/api/admin/loans/${loanLedgerId}/repayment`, { amount });
+    }
+
+    async function cancelLoan() {
+      const loanLedgerId = document.getElementById('ledger-id').value;
+      await callApi('DELETE', `/api/admin/loans/${loanLedgerId}`);
+    }
+
+    async function fetchLoans() {
+      const userId = document.getElementById('loan-list-user').value;
+      await callApi('GET', `/api/admin/users/${userId}/loans`);
+    }
+  </script>
+</body>
+</html>

--- a/bank/src/main/resources/templates/admin/index.html
+++ b/bank/src/main/resources/templates/admin/index.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>관리자 포털</title>
+  <style>
+    :root {
+      --bg: #f4f9ff;
+      --panel: rgba(255, 255, 255, 0.86);
+      --accent: #0d6efd;
+      --accent-2: #00b7ff;
+      --text: #0a2540;
+      --muted: #425466;
+      --border: #d8e3f2;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: 'Pretendard', 'Segoe UI', sans-serif;
+      background: radial-gradient(circle at 15% 20%, rgba(0, 183, 255, 0.15), transparent 25%),
+        radial-gradient(circle at 80% 10%, rgba(13, 110, 253, 0.16), transparent 26%),
+        linear-gradient(180deg, #f7fbff, #f1f6ff 40%, #f7fbff 70%);
+      color: var(--text);
+    }
+    header {
+      position: relative;
+      overflow: hidden;
+      padding: 32px 28px 40px;
+      background: linear-gradient(135deg, #e6f1ff 0%, #f9fdff 70%);
+      border-bottom: 1px solid var(--border);
+    }
+    header:after {
+      content: '';
+      position: absolute;
+      right: -120px;
+      top: -140px;
+      width: 320px;
+      height: 320px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(0, 183, 255, 0.25) 0%, rgba(13, 110, 253, 0.05) 70%);
+      filter: blur(12px);
+    }
+    h1 { margin: 0 0 10px; letter-spacing: -0.02em; }
+    p { margin: 4px 0; color: var(--muted); }
+    .grid {
+      display: grid;
+      gap: 18px;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      padding: 26px;
+    }
+    .card {
+      position: relative;
+      overflow: hidden;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 18px;
+      box-shadow: 0 18px 40px rgba(12, 70, 156, 0.08);
+      transition: transform 140ms ease, box-shadow 140ms ease;
+      backdrop-filter: blur(4px);
+    }
+    .card:before {
+      content: '';
+      position: absolute;
+      right: -40px;
+      bottom: -60px;
+      width: 160px;
+      height: 160px;
+      background: radial-gradient(circle, rgba(0, 183, 255, 0.14), transparent 60%);
+      transform: rotate(15deg);
+    }
+    .card:hover { transform: translateY(-3px); box-shadow: 0 22px 48px rgba(12, 70, 156, 0.12); }
+    a.button,
+    .button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      margin-top: 12px;
+      padding: 11px 14px;
+      background: linear-gradient(135deg, var(--accent), var(--accent-2));
+      color: #fff;
+      border-radius: 12px;
+      text-decoration: none;
+      font-weight: 800;
+      letter-spacing: -0.01em;
+      box-shadow: 0 10px 24px rgba(13, 110, 253, 0.25);
+      border: none;
+      cursor: pointer;
+    }
+    .token-box { max-width: 520px; margin-top: 16px; }
+    label { font-size: 13px; color: var(--muted); display: block; margin-bottom: 6px; }
+    input {
+      width: 100%; padding: 12px; border-radius: 12px; border: 1px solid var(--border);
+      font-size: 14px; background: #fff;
+      box-shadow: inset 0 1px 2px rgba(0,0,0,0.03);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>관리자 포털</h1>
+    <p>로그인 후 기능 페이지로 이동하세요. (ADMIN 권한 계정 필요)</p>
+    <div class="token-box">
+      <a class="button" style="width:100%; justify-content:center;" href="/admin/login">로그인 페이지로 이동</a>
+      <button class="button" style="width:100%; justify-content:center; background:#fff;color:#0a2540;border:1px solid var(--border);box-shadow:none;margin-top:10px;" onclick="logout()">로그아웃</button>
+      <p id="login-status" style="margin-top:8px; color: var(--muted);"></p>
+    </div>
+  </header>
+
+  <div class="grid">
+    <div class="card">
+      <h3>계좌 관리</h3>
+      <p>계좌 생성, 조회, 입출금, 송금, 카드 결제를 처리합니다.</p>
+      <a class="button" href="/admin/accounts">이동</a>
+    </div>
+    <div class="card">
+      <h3>대출 관리</h3>
+      <p>사용자 대출 가입, 상환/해지, 대출 목록 조회를 처리합니다.</p>
+      <a class="button" href="/admin/loans">이동</a>
+    </div>
+    <div class="card">
+      <h3>상품 관리</h3>
+      <p>대출 상품을 생성하고 상품 목록을 확인합니다.</p>
+      <a class="button" href="/admin/products">이동</a>
+    </div>
+  </div>
+
+  <script>
+    const loginStatus = document.getElementById('login-status');
+    const saved = localStorage.getItem('admin_token');
+    if (!saved || !hasAdminRole(saved)) {
+      loginStatus.textContent = '로그인이 필요하거나 ADMIN 권한이 없습니다. 로그인 페이지로 이동합니다.';
+      localStorage.removeItem('admin_token');
+      localStorage.removeItem('admin_refresh_token');
+      setTimeout(() => (window.location.href = '/admin/login'), 700);
+    } else {
+      loginStatus.textContent = '로그인 상태가 확인되었습니다. 메뉴를 선택하세요.';
+    }
+
+    function logout() {
+      localStorage.removeItem('admin_token');
+      localStorage.removeItem('admin_refresh_token');
+      loginStatus.textContent = '로그아웃되었습니다. 로그인 페이지로 이동합니다.';
+      setTimeout(() => (window.location.href = '/admin/login'), 400);
+    }
+
+    function hasAdminRole(token) {
+      try {
+        const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+        const roles = payload.role || payload.roles || [];
+        return Array.isArray(roles) && roles.includes('ROLE_ADMIN');
+      } catch (_) {
+        return false;
+      }
+    }
+  </script>
+</body>
+</html>

--- a/bank/src/main/resources/templates/admin/index.html
+++ b/bank/src/main/resources/templates/admin/index.html
@@ -129,31 +129,15 @@
 
   <script>
     const loginStatus = document.getElementById('login-status');
-    const saved = localStorage.getItem('admin_token');
-    if (!saved || !hasAdminRole(saved)) {
-      loginStatus.textContent = '로그인이 필요하거나 ADMIN 권한이 없습니다. 로그인 페이지로 이동합니다.';
-      localStorage.removeItem('admin_token');
-      localStorage.removeItem('admin_refresh_token');
-      setTimeout(() => (window.location.href = '/admin/login'), 700);
-    } else {
-      loginStatus.textContent = '로그인 상태가 확인되었습니다. 메뉴를 선택하세요.';
-    }
+
+    // 클라이언트에서 토큰을 판별하지 않고, 로그인 페이지에서 쿠키 발급 후 메뉴를 사용하도록 안내
+    loginStatus.textContent = '로그인 후 메뉴를 선택하세요.';
 
     function logout() {
-      localStorage.removeItem('admin_token');
-      localStorage.removeItem('admin_refresh_token');
-      loginStatus.textContent = '로그아웃되었습니다. 로그인 페이지로 이동합니다.';
-      setTimeout(() => (window.location.href = '/admin/login'), 400);
-    }
-
-    function hasAdminRole(token) {
-      try {
-        const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
-        const roles = payload.role || payload.roles || [];
-        return Array.isArray(roles) && roles.includes('ROLE_ADMIN');
-      } catch (_) {
-        return false;
-      }
+      fetch('/api/logout', { method: 'POST', credentials: 'include' }).finally(() => {
+        loginStatus.textContent = '로그아웃되었습니다. 로그인 페이지로 이동합니다.';
+        setTimeout(() => (window.location.href = '/admin/login'), 400);
+      });
     }
   </script>
 </body>

--- a/bank/src/main/resources/templates/admin/loans.html
+++ b/bank/src/main/resources/templates/admin/loans.html
@@ -111,8 +111,6 @@
         window.adminCommon;
     const state = { products: [], accounts: [], users: [], selectedUserId: null };
 
-    if (!ensureAdminOrRedirect()) return;
-
     document.addEventListener('DOMContentLoaded', () => {
       loadProducts();
       renderAccountOptions();

--- a/bank/src/main/resources/templates/admin/loans.html
+++ b/bank/src/main/resources/templates/admin/loans.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>대출 관리 | 관리자</title>
+  <style>
+    :root { --bg:#f4f9ff; --panel:rgba(255,255,255,0.9); --accent:#0d6efd; --accent-2:#00b7ff; --text:#0a2540; --muted:#425466; --border:#d8e3f2; }
+    * { box-sizing: border-box; }
+    body { margin:0; font-family:'Pretendard','Segoe UI',sans-serif; background:radial-gradient(circle at 18% 22%, rgba(0,183,255,0.12), transparent 28%), radial-gradient(circle at 78% 6%, rgba(13,110,253,0.12), transparent 30%), linear-gradient(180deg, #f7fbff, #eef5ff 45%, #f7fbff 80%); color:var(--text); }
+    header { position:relative; overflow:hidden; padding:24px; background:linear-gradient(135deg, #e5f1ff, #f9fdff); border-bottom:1px solid var(--border); }
+    header:after { content:''; position:absolute; right:-120px; top:-140px; width:320px; height:320px; border-radius:50%; background: radial-gradient(circle, rgba(0,183,255,0.22), transparent 60%); filter: blur(10px); }
+    h1 { margin:0 0 6px; letter-spacing:-0.02em; }
+    p { margin:0; color:var(--muted); }
+    .grid { display:grid; gap:18px; grid-template-columns: repeat(auto-fit,minmax(340px,1fr)); padding:22px; }
+    .card { position:relative; overflow:hidden; background:var(--panel); border:1px solid var(--border); border-radius:16px; padding:16px; box-shadow:0 16px 36px rgba(12,70,156,0.08); backdrop-filter: blur(4px); }
+    .card:before { content:''; position:absolute; right:-40px; bottom:-50px; width:150px; height:150px; background: radial-gradient(circle, rgba(0,183,255,0.16), transparent 60%); }
+    label { display:block; font-size:13px; color:var(--muted); margin:8px 0 4px; }
+    input, select { width:100%; padding:11px; border-radius:12px; border:1px solid var(--border); font-size:14px; background:#fff; box-shadow: inset 0 1px 2px rgba(0,0,0,0.03); }
+    button { margin-top:12px; width:100%; padding:11px; background:linear-gradient(135deg,var(--accent),var(--accent-2)); color:#fff; border:none; border-radius:12px; font-weight:800; cursor:pointer; box-shadow:0 12px 26px rgba(13,110,253,0.22); letter-spacing:-0.01em; }
+    .pill-row { display:flex; flex-wrap:wrap; gap:8px; margin-top:8px; }
+    .pill { padding:6px 10px; border-radius:18px; border:1px solid var(--border); background:#f8fbff; }
+    .result { background:#0f172a; color:#e5e7eb; border-radius:12px; padding:14px; margin:20px; min-height:160px; white-space:pre-wrap; font-family:'JetBrains Mono','SFMono-Regular',monospace; box-shadow:0 16px 32px rgba(0,0,0,0.08); }
+    .link-back { color: var(--accent); text-decoration: none; font-weight: 800; }
+  </style>
+</head>
+<body>
+  <header>
+    <a class="link-back" href="/admin">← 관리자 홈</a>
+    <h1>대출 관리</h1>
+    <p>ADMIN 로그인 후 접근 가능합니다. 토큰이 없으면 홈으로 이동합니다.</p>
+    <div style="max-width:520px; margin-top: 10px;">
+      <label for="token">Access Token (읽기 전용)</label>
+      <input id="token" type="text" readonly />
+      <button style="margin-top:10px; padding:10px; border-radius:10px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;" onclick="logout()">로그아웃</button>
+    </div>
+  </header>
+
+  <div class="grid">
+    <div class="card">
+      <h3>사용자 선택</h3>
+      <button onclick="fetchUsers()">사용자 목록 불러오기</button>
+      <div id="user-pills" class="pill-row" style="margin-top:8px;"></div>
+      <div class="hint">사용자를 선택하면 계좌와 대출 작업 대상이 됩니다.</div>
+    </div>
+
+    <div class="card">
+      <h3>대출 상품 선택</h3>
+      <label>대출 상품</label>
+      <select id="loan-product-select"></select>
+      <button onclick="loadProducts()">상품 목록 새로고침</button>
+      <div id="product-list" class="pill-row"></div>
+    </div>
+
+    <div class="card">
+      <h3>대출 가입</h3>
+      <label>사용자 (선택됨)</label>
+      <div id="selected-user" style="padding:8px 10px; border:1px solid var(--border); border-radius:10px; background:#fff; min-height:36px;">사용자를 선택하세요.</div>
+      <label>대출 상품</label>
+      <select id="loan-product-select-join"></select>
+      <label>대출 계좌</label>
+      <select id="loan-account-select"></select>
+      <label>원금</label>
+      <input id="loan-principal" type="number" />
+      <label>금리 유형</label>
+      <select id="loan-interest">
+        <option value="FIXED">FIXED</option>
+        <option value="VARIABLE">VARIABLE</option>
+      </select>
+      <label>상환 방법</label>
+      <select id="loan-repayment">
+        <option value="EQUAL_INSTALLMENT">EQUAL_INSTALLMENT</option>
+        <option value="EQUAL_PRINCIPAL">EQUAL_PRINCIPAL</option>
+        <option value="BULLET">BULLET</option>
+      </select>
+      <label>상환 기간(년)</label>
+      <input id="loan-term" type="number" />
+      <label>자동 예치 여부</label>
+      <select id="loan-auto">
+        <option value="true">true</option>
+        <option value="false">false</option>
+      </select>
+      <button onclick="applyLoan()">대출 가입</button>
+    </div>
+
+    <div class="card">
+      <h3>대출 상환 / 해지</h3>
+      <label>대출 원장 ID</label>
+      <input id="ledger-id" type="number" />
+      <label>상환 금액</label>
+      <input id="repay-amount" type="number" />
+      <button onclick="repayLoan()">상환</button>
+      <button onclick="cancelLoan()">해지</button>
+    </div>
+
+    <div class="card">
+      <h3>사용자 대출 목록</h3>
+      <label>사용자 ID</label>
+      <input id="loan-list-user" type="number" />
+      <button onclick="fetchLoans()">조회</button>
+    </div>
+  </div>
+
+  <div class="result" id="result">응답이 여기에 표시됩니다.</div>
+
+  <script>
+    const resultBox = document.getElementById('result');
+    const tokenInput = document.getElementById('token');
+    const state = { products: [], accounts: [], users: [], selectedUserId: null };
+
+    const saved = localStorage.getItem('admin_token');
+    if (!saved || !hasAdminRole(saved)) {
+      alert('ADMIN 권한이 필요합니다.');
+      localStorage.removeItem('admin_token');
+      localStorage.removeItem('admin_refresh_token');
+      location.href = '/admin/login';
+    } else {
+      tokenInput.value = saved;
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      loadProducts();
+      renderAccountOptions();
+      fetchUsers();
+    });
+
+    function extractPayload(json) {
+      if (!json || typeof json !== 'object') return null;
+      return json?.data?.body?.data ?? json?.data?.data ?? json?.data ?? json?.result ?? json;
+    }
+
+    async function callApi(method, url, body) {
+      const token = tokenInput.value.trim();
+      if (!token) { resultBox.textContent = '토큰을 입력하세요.'; return null; }
+      const init = { method, headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` } };
+      if (body) init.body = JSON.stringify(body);
+      const res = await fetch(url, init);
+      const text = await res.text();
+      let parsed = null;
+      try { parsed = JSON.parse(text); resultBox.textContent = JSON.stringify(parsed, null, 2); }
+      catch (_) { resultBox.textContent = text; }
+      return parsed ?? text;
+    }
+
+    function logout() {
+      localStorage.removeItem('admin_token');
+      localStorage.removeItem('admin_refresh_token');
+      location.href = '/admin/login';
+    }
+
+    function hasAdminRole(token) {
+      try {
+        const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+        const roles = payload.role || payload.roles || [];
+        return Array.isArray(roles) && roles.includes('ROLE_ADMIN');
+      } catch (_) {
+        return false;
+      }
+    }
+
+    async function loadProducts() {
+      try {
+        const res = await fetch('/api/loans/products?size=50');
+        const json = await res.json();
+        const payload = extractPayload(json);
+        state.products = payload?.content ?? payload ?? [];
+        renderProducts();
+      } catch (e) { resultBox.textContent = '대출 상품 조회 실패: ' + e; }
+    }
+
+    function renderProducts() {
+      const select = document.getElementById('loan-product-select');
+      const selectJoin = document.getElementById('loan-product-select-join');
+      const list = document.getElementById('product-list');
+      select.innerHTML = ''; selectJoin.innerHTML = ''; list.innerHTML = '';
+      state.products.forEach(p => {
+        const option = document.createElement('option');
+        option.value = p.loanProductId ?? p.id ?? p.loanProductId;
+        option.textContent = `${p.name ?? '상품'} (#${option.value})`;
+        select.appendChild(option.cloneNode(true));
+        selectJoin.appendChild(option);
+        const pill = document.createElement('div'); pill.className='pill'; pill.textContent = `${p.name ?? '상품'} · ${p.type ?? ''}`; list.appendChild(pill);
+      });
+    }
+
+    function renderAccountOptions() {
+      const sel = document.getElementById('loan-account-select');
+      sel.innerHTML = '';
+      const ph = document.createElement('option'); ph.value=''; ph.textContent='계좌 선택'; sel.appendChild(ph);
+      state.accounts.forEach(a => {
+        const opt = document.createElement('option');
+        const num = a.accountNumber ?? a.account_number;
+        opt.value = num; opt.textContent = `${num} (잔액: ${a.balance ?? '-'})`;
+        sel.appendChild(opt);
+      });
+      const pills = document.getElementById('account-pills'); pills.innerHTML='';
+      state.accounts.forEach(a => { const pill = document.createElement('div'); pill.className='pill'; pill.textContent = `${a.accountNumber ?? a.account_number} · 잔액 ${a.balance ?? '-'}`; pills.appendChild(pill); });
+    }
+
+    function renderUsers() {
+      const wrap = document.getElementById('user-pills');
+      wrap.innerHTML = '';
+      state.users.forEach(u => {
+        const pill = document.createElement('div');
+        pill.className = 'pill';
+        pill.style.cursor = 'pointer';
+        pill.textContent = `${u.name} (#${u.userId}) / ${u.loginId}`;
+        pill.onclick = () => selectUser(u.userId);
+        if (state.selectedUserId === u.userId) {
+          pill.style.background = '#e7f2ff';
+          pill.style.borderColor = '#0d6efd';
+        }
+        wrap.appendChild(pill);
+      });
+      const selected = document.getElementById('selected-user');
+      if (state.selectedUserId) {
+        const user = state.users.find(u => u.userId === state.selectedUserId);
+        selected.textContent = user ? `${user.name} (#${user.userId}) / ${user.loginId}` : '선택됨';
+      } else {
+        selected.textContent = '사용자를 선택하세요.';
+      }
+    }
+
+    function selectUser(userId) {
+      state.selectedUserId = userId;
+      renderUsers();
+      fetchAccounts();
+    }
+
+    async function fetchAccounts() {
+      const userId = state.selectedUserId;
+      if (!userId) return;
+      const json = await callApi('GET', `/api/admin/users/${userId}/accounts`);
+      const payload = extractPayload(json);
+      if (Array.isArray(payload)) { state.accounts = payload; renderAccountOptions(); }
+    }
+
+    async function fetchUsers() {
+      const json = await callApi('GET', '/api/admin/users');
+      const payload = extractPayload(json);
+      if (Array.isArray(payload)) {
+        state.users = payload;
+        renderUsers();
+      }
+    }
+
+    async function applyLoan() {
+      const userId = state.selectedUserId;
+      const loanProductId = document.getElementById('loan-product-select-join').value;
+      const accountNumber = document.getElementById('loan-account-select').value;
+      const principal = Number(document.getElementById('loan-principal').value);
+      const interestType = document.getElementById('loan-interest').value;
+      const repaymentType = document.getElementById('loan-repayment').value;
+      const term = Number(document.getElementById('loan-term').value);
+      const autoDepositEnabled = document.getElementById('loan-auto').value === 'true';
+      if (!userId) return resultBox.textContent = '사용자를 선택하세요.';
+      if (!loanProductId || !accountNumber) return resultBox.textContent = '대출 상품과 계좌를 선택하세요.';
+      await callApi('POST', `/api/admin/users/${userId}/loans/${loanProductId}`, { principal, interestType, repaymentType, term, accountNumber, autoDepositEnabled });
+    }
+
+    async function repayLoan() {
+      const loanLedgerId = document.getElementById('ledger-id').value;
+      const amount = Number(document.getElementById('repay-amount').value);
+      await callApi('POST', `/api/admin/loans/${loanLedgerId}/repayment`, { amount });
+    }
+
+    async function cancelLoan() {
+      const loanLedgerId = document.getElementById('ledger-id').value;
+      await callApi('DELETE', `/api/admin/loans/${loanLedgerId}`);
+    }
+
+    async function fetchLoans() {
+      const userId = state.selectedUserId;
+      if (!userId) return resultBox.textContent = '사용자를 선택하세요.';
+      await callApi('GET', `/api/admin/users/${userId}/loans`);
+    }
+  </script>
+</body>
+</html>

--- a/bank/src/main/resources/templates/admin/loans.html
+++ b/bank/src/main/resources/templates/admin/loans.html
@@ -32,7 +32,7 @@
     <div style="max-width:520px; margin-top: 10px;">
       <label for="token">Access Token (읽기 전용)</label>
       <input id="token" type="text" readonly />
-      <button style="margin-top:10px; padding:10px; border-radius:10px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;" onclick="logout()">로그아웃</button>
+      <button style="margin-top:10px; padding:10px; border-radius:10px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;" onclick="logoutAndRedirect()">로그아웃</button>
     </div>
   </header>
 
@@ -103,60 +103,21 @@
 
   <div class="result" id="result">응답이 여기에 표시됩니다.</div>
 
+  <script src="/js/admin-common.js"></script>
   <script>
     const resultBox = document.getElementById('result');
     const tokenInput = document.getElementById('token');
+    const { callApi, extractPayload, hasAdminRole, ensureAdminOrRedirect, logoutAndRedirect } =
+        window.adminCommon;
     const state = { products: [], accounts: [], users: [], selectedUserId: null };
 
-    const saved = localStorage.getItem('admin_token');
-    if (!saved || !hasAdminRole(saved)) {
-      alert('ADMIN 권한이 필요합니다.');
-      localStorage.removeItem('admin_token');
-      localStorage.removeItem('admin_refresh_token');
-      location.href = '/admin/login';
-    } else {
-      tokenInput.value = saved;
-    }
+    if (!ensureAdminOrRedirect()) return;
 
     document.addEventListener('DOMContentLoaded', () => {
       loadProducts();
       renderAccountOptions();
       fetchUsers();
     });
-
-    function extractPayload(json) {
-      if (!json || typeof json !== 'object') return null;
-      return json?.data?.body?.data ?? json?.data?.data ?? json?.data ?? json?.result ?? json;
-    }
-
-    async function callApi(method, url, body) {
-      const token = tokenInput.value.trim();
-      if (!token) { resultBox.textContent = '토큰을 입력하세요.'; return null; }
-      const init = { method, headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` } };
-      if (body) init.body = JSON.stringify(body);
-      const res = await fetch(url, init);
-      const text = await res.text();
-      let parsed = null;
-      try { parsed = JSON.parse(text); resultBox.textContent = JSON.stringify(parsed, null, 2); }
-      catch (_) { resultBox.textContent = text; }
-      return parsed ?? text;
-    }
-
-    function logout() {
-      localStorage.removeItem('admin_token');
-      localStorage.removeItem('admin_refresh_token');
-      location.href = '/admin/login';
-    }
-
-    function hasAdminRole(token) {
-      try {
-        const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
-        const roles = payload.role || payload.roles || [];
-        return Array.isArray(roles) && roles.includes('ROLE_ADMIN');
-      } catch (_) {
-        return false;
-      }
-    }
 
     async function loadProducts() {
       try {

--- a/bank/src/main/resources/templates/admin/login.html
+++ b/bank/src/main/resources/templates/admin/login.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>관리자 로그인</title>
+  <style>
+    :root {
+      --bg: #f4f9ff;
+      --panel: rgba(255, 255, 255, 0.9);
+      --accent: #0d6efd;
+      --accent-2: #00b7ff;
+      --text: #0a2540;
+      --muted: #425466;
+      --border: #d8e3f2;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: 'Pretendard', 'Segoe UI', sans-serif;
+      background: radial-gradient(circle at 20% 20%, rgba(0, 183, 255, 0.12), transparent 28%),
+        radial-gradient(circle at 80% 0%, rgba(13, 110, 253, 0.12), transparent 30%),
+        linear-gradient(180deg, #f7fbff, #eef5ff 45%, #f7fbff 80%);
+      color: var(--text);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 20px;
+    }
+    .card {
+      position: relative;
+      width: 100%;
+      max-width: 420px;
+      padding: 24px;
+      border-radius: 18px;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      box-shadow: 0 24px 48px rgba(12, 70, 156, 0.12);
+      backdrop-filter: blur(6px);
+      overflow: hidden;
+    }
+    .card:before {
+      content: '';
+      position: absolute;
+      right: -60px;
+      bottom: -80px;
+      width: 220px;
+      height: 220px;
+      background: radial-gradient(circle, rgba(0, 183, 255, 0.18), transparent 60%);
+    }
+    h1 { margin: 0 0 10px; letter-spacing: -0.02em; }
+    p { margin: 0 0 14px; color: var(--muted); }
+    label { display: block; margin: 10px 0 6px; font-size: 13px; color: var(--muted); }
+    input {
+      width: 100%;
+      padding: 12px;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      font-size: 14px;
+      background: #fff;
+      box-shadow: inset 0 1px 2px rgba(0,0,0,0.03);
+    }
+    .button {
+      margin-top: 16px;
+      width: 100%;
+      padding: 12px;
+      background: linear-gradient(135deg, var(--accent), var(--accent-2));
+      color: #fff;
+      border: none;
+      border-radius: 12px;
+      font-weight: 800;
+      letter-spacing: -0.01em;
+      box-shadow: 0 14px 30px rgba(13, 110, 253, 0.22);
+      cursor: pointer;
+    }
+    .status { margin-top: 10px; font-size: 13px; color: var(--muted); }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>관리자 로그인</h1>
+    <p>ADMIN 권한 계정으로 로그인하세요.</p>
+    <label for="loginId">Login ID</label>
+    <input id="loginId" type="text" placeholder="admin" />
+    <label for="password">Password</label>
+    <input id="password" type="password" placeholder="••••••" />
+    <button class="button" onclick="login()">로그인</button>
+    <button class="button" style="background:#fff;color:#0a2540;border:1px solid var(--border);box-shadow:none;margin-top:10px;" onclick="logout()">로그아웃</button>
+    <div id="status" class="status"></div>
+  </div>
+
+  <script>
+    const status = document.getElementById('status');
+
+    // 이미 ADMIN 토큰이 있으면 메인으로 보냄
+    const saved = localStorage.getItem('admin_token');
+    if (saved && hasAdminRole(saved)) {
+      window.location.href = '/admin';
+    }
+
+    async function login() {
+      const loginId = document.getElementById('loginId').value.trim();
+      const password = document.getElementById('password').value.trim();
+      if (!loginId || !password) {
+        status.textContent = '아이디와 비밀번호를 입력하세요.';
+        return;
+      }
+      try {
+        const res = await fetch('/api/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ loginId, password }),
+        });
+        const text = await res.text();
+        const json = JSON.parse(text);
+        if (json && json.access_token) {
+          if (!hasAdminRole(json.access_token)) {
+            status.textContent = '로그인 실패: 관리자가 아닙니다.';
+            return;
+          }
+          localStorage.setItem('admin_token', json.access_token);
+          localStorage.setItem('admin_refresh_token', json.refresh_token ?? '');
+          status.textContent = '로그인 성공! 잠시 후 이동합니다...';
+          setTimeout(() => (window.location.href = '/admin'), 500);
+        } else {
+          status.textContent = '로그인 실패: 토큰을 받지 못했습니다.';
+        }
+      } catch (e) {
+        status.textContent = '로그인 실패: ' + e;
+      }
+    }
+
+    function logout() {
+      localStorage.removeItem('admin_token');
+      localStorage.removeItem('admin_refresh_token');
+      status.textContent = '로그아웃되었습니다. 다시 로그인하세요.';
+    }
+
+    function hasAdminRole(token) {
+      try {
+        const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+        const roles = payload.role || payload.roles || [];
+        return Array.isArray(roles) && roles.includes('ROLE_ADMIN');
+      } catch (_) {
+        return false;
+      }
+    }
+  </script>
+</body>
+</html>

--- a/bank/src/main/resources/templates/admin/login.html
+++ b/bank/src/main/resources/templates/admin/login.html
@@ -106,6 +106,7 @@
         const res = await fetch('/api/login', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
           body: JSON.stringify({ loginId, password }),
         });
         if (!res.ok) {

--- a/bank/src/main/resources/templates/admin/login.html
+++ b/bank/src/main/resources/templates/admin/login.html
@@ -93,11 +93,7 @@
   <script>
     const status = document.getElementById('status');
 
-    // 이미 ADMIN 토큰이 있으면 메인으로 보냄
-    const saved = localStorage.getItem('admin_token');
-    if (saved && hasAdminRole(saved)) {
-      window.location.href = '/admin';
-    }
+    // 클라이언트에서는 로그인 유무 판별 없이 사용자가 로그인 시도하도록 둔다.
 
     async function login() {
       const loginId = document.getElementById('loginId').value.trim();
@@ -112,29 +108,32 @@
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ loginId, password }),
         });
+        if (!res.ok) {
+          status.textContent = '로그인 실패: ' + res.status;
+          return;
+        }
+        // 토큰은 쿠키로 처리하므로 바디 저장 없이 바로 이동
         const text = await res.text();
-        const json = JSON.parse(text);
-        if (json && json.access_token) {
-          if (!hasAdminRole(json.access_token)) {
+        try {
+          const json = JSON.parse(text);
+          if (json && json.access_token && !hasAdminRole(json.access_token)) {
             status.textContent = '로그인 실패: 관리자가 아닙니다.';
             return;
           }
-          localStorage.setItem('admin_token', json.access_token);
-          localStorage.setItem('admin_refresh_token', json.refresh_token ?? '');
-          status.textContent = '로그인 성공! 잠시 후 이동합니다...';
-          setTimeout(() => (window.location.href = '/admin'), 500);
-        } else {
-          status.textContent = '로그인 실패: 토큰을 받지 못했습니다.';
+        } catch (_) {
+          // 바디 파싱 실패 시에도 쿠키만으로 진행
         }
+        status.textContent = '로그인 성공! 잠시 후 이동합니다...';
+        setTimeout(() => (window.location.href = '/admin'), 500);
       } catch (e) {
         status.textContent = '로그인 실패: ' + e;
       }
     }
 
     function logout() {
-      localStorage.removeItem('admin_token');
-      localStorage.removeItem('admin_refresh_token');
-      status.textContent = '로그아웃되었습니다. 다시 로그인하세요.';
+      fetch('/api/logout', { method: 'POST', credentials: 'include' }).finally(() => {
+        status.textContent = '로그아웃되었습니다. 다시 로그인하세요.';
+      });
     }
 
     function hasAdminRole(token) {

--- a/bank/src/main/resources/templates/admin/login.html
+++ b/bank/src/main/resources/templates/admin/login.html
@@ -92,6 +92,11 @@
 
   <script>
     const status = document.getElementById('status');
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        login();
+      }
+    });
 
     // 클라이언트에서는 로그인 유무 판별 없이 사용자가 로그인 시도하도록 둔다.
 

--- a/bank/src/main/resources/templates/admin/products.html
+++ b/bank/src/main/resources/templates/admin/products.html
@@ -37,7 +37,7 @@
     <div style="max-width:520px; margin-top: 10px;">
       <label for="token">Access Token (읽기 전용)</label>
       <input id="token" type="text" readonly />
-      <button style="margin-top:10px; padding:10px; border-radius:10px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;" onclick="logout()">로그아웃</button>
+      <button style="margin-top:10px; padding:10px; border-radius:10px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;" onclick="logoutAndRedirect()">로그아웃</button>
     </div>
   </header>
 
@@ -67,56 +67,16 @@
 
   <div class="result" id="result">응답이 여기에 표시됩니다.</div>
 
+  <script src="/js/admin-common.js"></script>
   <script>
     const resultBox = document.getElementById('result');
     const tokenInput = document.getElementById('token');
+    const { callApi, extractPayload, ensureAdminOrRedirect, logoutAndRedirect } = window.adminCommon;
     const state = { products: [] };
 
-    const saved = localStorage.getItem('admin_token');
-    if (!saved || !hasAdminRole(saved)) {
-      alert('ADMIN 권한이 필요합니다.');
-      localStorage.removeItem('admin_token');
-      localStorage.removeItem('admin_refresh_token');
-      location.href = '/admin/login';
-    } else {
-      tokenInput.value = saved;
-    }
+    if (!ensureAdminOrRedirect()) return;
 
     document.addEventListener('DOMContentLoaded', loadProducts);
-
-    function extractPayload(json) {
-      if (!json || typeof json !== 'object') return null;
-      return json?.data?.body?.data ?? json?.data?.data ?? json?.data ?? json?.result ?? json;
-    }
-
-    async function callApi(method, url, body) {
-      const token = tokenInput.value.trim();
-      if (!token) { resultBox.textContent = '토큰을 입력하세요.'; return null; }
-      const init = { method, headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` } };
-      if (body) init.body = JSON.stringify(body);
-      const res = await fetch(url, init);
-      const text = await res.text();
-      let parsed = null;
-      try { parsed = JSON.parse(text); resultBox.textContent = JSON.stringify(parsed, null, 2); }
-      catch (_) { resultBox.textContent = text; }
-      return parsed ?? text;
-    }
-
-    function logout() {
-      localStorage.removeItem('admin_token');
-      localStorage.removeItem('admin_refresh_token');
-      location.href = '/admin/login';
-    }
-
-    function hasAdminRole(token) {
-      try {
-        const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
-        const roles = payload.role || payload.roles || [];
-        return Array.isArray(roles) && roles.includes('ROLE_ADMIN');
-      } catch (_) {
-        return false;
-      }
-    }
 
     async function createProduct() {
       const name = document.getElementById('prod-name').value;

--- a/bank/src/main/resources/templates/admin/products.html
+++ b/bank/src/main/resources/templates/admin/products.html
@@ -74,9 +74,12 @@
     const { callApi, extractPayload, ensureAdminOrRedirect, logoutAndRedirect } = window.adminCommon;
     const state = { products: [] };
 
-    if (!ensureAdminOrRedirect()) return;
-
-    document.addEventListener('DOMContentLoaded', loadProducts);
+    document.addEventListener('DOMContentLoaded', () => {
+      ensureAdminOrRedirect().then(ok => {
+        if (!ok) return;
+        loadProducts();
+      });
+    });
 
     async function createProduct() {
       const name = document.getElementById('prod-name').value;

--- a/bank/src/main/resources/templates/admin/products.html
+++ b/bank/src/main/resources/templates/admin/products.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>대출 상품 관리 | 관리자</title>
+  <style>
+    :root { --bg:#f4f9ff; --panel:rgba(255,255,255,0.9); --accent:#0d6efd; --accent-2:#00b7ff; --text:#0a2540; --muted:#425466; --border:#d8e3f2; }
+    * { box-sizing: border-box; }
+    body { margin:0; font-family:'Pretendard','Segoe UI',sans-serif; background:radial-gradient(circle at 20% 20%, rgba(0,183,255,0.12), transparent 28%), radial-gradient(circle at 80% 0%, rgba(13,110,253,0.12), transparent 30%), linear-gradient(180deg, #f7fbff, #eef5ff 45%, #f7fbff 80%); color:var(--text); }
+    header { position:relative; overflow:hidden; padding:24px; background:linear-gradient(135deg, #e5f1ff, #f9fdff); border-bottom:1px solid var(--border); }
+    header:after { content:''; position:absolute; right:-120px; top:-140px; width:320px; height:320px; border-radius:50%; background: radial-gradient(circle, rgba(0,183,255,0.22), transparent 60%); filter: blur(10px); }
+    h1 { margin:0 0 6px; letter-spacing:-0.02em; }
+    p { margin:0; color:var(--muted); }
+    .grid { display:grid; gap:18px; grid-template-columns: repeat(auto-fit,minmax(360px,1fr)); padding:22px; }
+    .card { position:relative; overflow:hidden; background:var(--panel); border:1px solid var(--border); border-radius:16px; padding:16px; box-shadow:0 16px 36px rgba(12,70,156,0.08); backdrop-filter: blur(4px); }
+    .card:before { content:''; position:absolute; right:-40px; bottom:-50px; width:150px; height:150px; background: radial-gradient(circle, rgba(0,183,255,0.16), transparent 60%); }
+    label { display:block; font-size:13px; color:var(--muted); margin:8px 0 4px; }
+    input, select { width:100%; padding:11px; border-radius:12px; border:1px solid var(--border); font-size:14px; background:#fff; box-shadow: inset 0 1px 2px rgba(0,0,0,0.03); }
+    button { margin-top:12px; width:100%; padding:11px; background:linear-gradient(135deg,var(--accent),var(--accent-2)); color:#fff; border:none; border-radius:12px; font-weight:800; cursor:pointer; box-shadow:0 12px 26px rgba(13,110,253,0.22); letter-spacing:-0.01em; }
+    .pill-row { display:flex; flex-wrap:wrap; gap:8px; margin-top:8px; }
+    .pill { padding:6px 10px; border-radius:18px; border:1px solid var(--border); background:#f8fbff; }
+    .product-grid { display:grid; grid-template-columns: repeat(auto-fit,minmax(260px,1fr)); gap:12px; margin-top:10px; }
+    .product-card { padding:14px; border:1px solid var(--border); border-radius:12px; background:#fff; box-shadow:0 10px 24px rgba(13,110,253,0.08); }
+    .product-name { font-weight:800; letter-spacing:-0.01em; }
+    .product-meta { color: var(--muted); font-size:13px; margin-top:6px; }
+    .result { background:#0f172a; color:#e5e7eb; border-radius:12px; padding:14px; margin:20px; min-height:160px; white-space:pre-wrap; font-family:'JetBrains Mono','SFMono-Regular',monospace; box-shadow:0 16px 32px rgba(0,0,0,0.08); }
+    .link-back { color: var(--accent); text-decoration: none; font-weight: 800; }
+    .ghost { background:#fff; color: var(--text); border:1px solid var(--border); box-shadow:none; }
+  </style>
+</head>
+<body>
+  <header>
+    <a class="link-back" href="/admin">← 관리자 홈</a>
+    <h1>대출 상품 관리</h1>
+    <p>ADMIN 로그인 후 접근 가능합니다. 토큰이 없으면 홈으로 이동합니다.</p>
+    <div style="max-width:520px; margin-top: 10px;">
+      <label for="token">Access Token (읽기 전용)</label>
+      <input id="token" type="text" readonly />
+      <button style="margin-top:10px; padding:10px; border-radius:10px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;" onclick="logout()">로그아웃</button>
+    </div>
+  </header>
+
+  <div class="grid">
+    <div class="card">
+      <h3>상품 생성</h3>
+      <label>상품 이름</label>
+      <input id="prod-name" type="text" />
+      <label>대출 유형</label>
+      <select id="prod-type">
+        <option value="CREDIT">CREDIT</option>
+        <option value="MORTGAGE">MORTGAGE</option>
+      </select>
+      <label>가산 금리</label>
+      <input id="prod-add" type="number" step="0.01" />
+      <label>우대 금리 상한</label>
+      <input id="prod-limit" type="number" step="0.01" />
+      <button onclick="createProduct()">상품 생성</button>
+    </div>
+
+    <div class="card">
+      <h3>상품 목록</h3>
+      <button class="ghost" onclick="loadProducts()">새로고침</button>
+      <div id="product-list" class="product-grid"></div>
+    </div>
+  </div>
+
+  <div class="result" id="result">응답이 여기에 표시됩니다.</div>
+
+  <script>
+    const resultBox = document.getElementById('result');
+    const tokenInput = document.getElementById('token');
+    const state = { products: [] };
+
+    const saved = localStorage.getItem('admin_token');
+    if (!saved || !hasAdminRole(saved)) {
+      alert('ADMIN 권한이 필요합니다.');
+      localStorage.removeItem('admin_token');
+      localStorage.removeItem('admin_refresh_token');
+      location.href = '/admin/login';
+    } else {
+      tokenInput.value = saved;
+    }
+
+    document.addEventListener('DOMContentLoaded', loadProducts);
+
+    function extractPayload(json) {
+      if (!json || typeof json !== 'object') return null;
+      return json?.data?.body?.data ?? json?.data?.data ?? json?.data ?? json?.result ?? json;
+    }
+
+    async function callApi(method, url, body) {
+      const token = tokenInput.value.trim();
+      if (!token) { resultBox.textContent = '토큰을 입력하세요.'; return null; }
+      const init = { method, headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` } };
+      if (body) init.body = JSON.stringify(body);
+      const res = await fetch(url, init);
+      const text = await res.text();
+      let parsed = null;
+      try { parsed = JSON.parse(text); resultBox.textContent = JSON.stringify(parsed, null, 2); }
+      catch (_) { resultBox.textContent = text; }
+      return parsed ?? text;
+    }
+
+    function logout() {
+      localStorage.removeItem('admin_token');
+      localStorage.removeItem('admin_refresh_token');
+      location.href = '/admin/login';
+    }
+
+    function hasAdminRole(token) {
+      try {
+        const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
+        const roles = payload.role || payload.roles || [];
+        return Array.isArray(roles) && roles.includes('ROLE_ADMIN');
+      } catch (_) {
+        return false;
+      }
+    }
+
+    async function createProduct() {
+      const name = document.getElementById('prod-name').value;
+      const type = document.getElementById('prod-type').value;
+      const addInterest = Number(document.getElementById('prod-add').value);
+      const limitPreferInterest = Number(document.getElementById('prod-limit').value);
+      await callApi('POST', '/api/loans', { name, type, addInterest, limitPreferInterest });
+    }
+
+    async function loadProducts() {
+      try {
+        const res = await fetch('/api/loans/products?size=50');
+        const json = await res.json();
+        const payload = extractPayload(json);
+        state.products = payload?.content ?? payload ?? [];
+        renderProducts();
+      } catch (e) { resultBox.textContent = '상품 조회 실패: ' + e; }
+    }
+
+    function renderProducts() {
+      const list = document.getElementById('product-list');
+      list.innerHTML = '';
+      state.products.forEach(p => {
+        const card = document.createElement('div');
+        card.className = 'product-card';
+
+        const name = document.createElement('div');
+        name.className = 'product-name';
+        name.textContent = `${p.name ?? '상품'} (#${p.loanProductId ?? p.id ?? ''})`;
+        const meta = document.createElement('div');
+        meta.className = 'product-meta';
+        meta.textContent = `유형: ${p.type ?? '-'} | 가산금리: ${p.addInterest ?? '-'} | 우대상한: ${p.limitPreferInterest ?? '-'}`;
+
+        card.appendChild(name);
+        card.appendChild(meta);
+        list.appendChild(card);
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
closes #131 

 ### 개요
  - 관리자 기능 UX 개선: 로그인/로그아웃 흐름 정리, ADMIN 권한 검증 강화, 페이지별 리다이렉트 추가
  - 관리자 전용 사용자 선택 기반 계좌/대출 조작 UI/UX 추가
  - 애플리케이션 구동 시 ADMIN 계정 생성 로직 추가

  ### 변경 사항
  - 시큐리티: /admin/login는 public, /admin/**는 프론트 리다이렉트, /api/admin/**는 여전히 ROLE_ADMIN 요구
  - 관리자 페이지
      - 관리자 로그인 페이지
      - 관리자 상품 관리 페이지
      - 관리자 계좌 관리 페이지
  - API/서비스
      - GET /api/admin/users 추가(사용자 목록: userId, name, loginId)
  - 시드
      - CommandLineRunner로 admin 계정 보장 (ADMIN_SEED_PASSWORD 환경변수 우선)
  - 로그인 쿠키
      - 로그인 성공 시, ResponseBody 및 Cookie 로 AT,RT 를 반환합니다.
      - 이후 JwtAuthenticationConverter 에서 Authentication 객체 변환 시, 1순위로 `Authorization` 헤더를 검사하고, 이후 `Cookie`를 검사합니다.

  ### 요약
  - ADMIN 토큰 없이 /admin/* 접근 시 로그인 페이지로 리다이렉트
  - ADMIN 토큰으로 로그인 후 계좌/대출/상품 페이지 접근 및 API 호출 정상
  - ADMIN 토큰 없거나 권한 부족 시 로그인 페이지/메시지로 차단
  - 애플리케이션 구동 시 admin 계정 자동 생성 (이미 존재하면 스킵)