### PR TITLE
[FIX] login redirect 안되는 오류 수정

### DIFF
--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/SecurityFilterChainConfig.java
@@ -245,11 +245,11 @@ public class SecurityFilterChainConfig {
   /** 시큐리티 기본 로그인 및 에러 리다이렉트 필터체인 */
   @Bean
   @Order(5)
-  public SecurityFilterChain loginFilterChain(
+  public SecurityFilterChain securityDefaultLoginFilterChain(
       HttpSecurity http,
       @Qualifier("UsernamePasswordAuthenticationProvider")
           AuthenticationProvider authenticationProvider,
-      @Qualifier("LoginSuccessHandler") AuthenticationSuccessHandler loginSuccessHandler,
+      @Qualifier("FormLoginSuccessHandler") AuthenticationSuccessHandler loginSuccessHandler,
       @Qualifier("LoginFailureHandler") AuthenticationFailureHandler loginFailureHandler)
       throws Exception {
 

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
@@ -101,6 +101,13 @@ public class AuthorizationConfig {
     return new LoginSuccessHandler(jwtGenerator, objectMapper, userAuthRepository);
   }
 
+  @Bean("FormLoginSuccessHandler")
+  public AuthenticationSuccessHandler formLoginSuccessHandler(
+      UserAuthRepository userAuthRepository,
+      UserJwtGenerator jwtGenerator) {
+    return new RequestAwareLoginSuccessHandler(jwtGenerator, userAuthRepository);
+  }
+
   @Bean("UsernamePasswordAuthenticationConverter")
   public AuthenticationConverter usernamePasswordAuthenticationConverter(ObjectMapper om) {
     return new UsernamePasswordAuthenticationConverter(om);

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/AuthorizationConfig.java
@@ -103,8 +103,7 @@ public class AuthorizationConfig {
 
   @Bean("FormLoginSuccessHandler")
   public AuthenticationSuccessHandler formLoginSuccessHandler(
-      UserAuthRepository userAuthRepository,
-      UserJwtGenerator jwtGenerator) {
+      UserAuthRepository userAuthRepository, UserJwtGenerator jwtGenerator) {
     return new RequestAwareLoginSuccessHandler(jwtGenerator, userAuthRepository);
   }
 

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/RequestAwareLoginSuccessHandler.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/RequestAwareLoginSuccessHandler.java
@@ -1,0 +1,66 @@
+package com.fisa.bank.domains.common.config.security.resource;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Objects;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+
+import com.fisa.bank.domains.common.config.security.jwt.UserJwtGenerator;
+import com.fisa.bank.domains.common.presentation.util.CookieUtils;
+import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
+
+/**
+ * 폼 로그인 성공 시 JWT 쿠키를 심은 뒤, SavedRequest로 리다이렉트한다.
+ */
+  @Slf4j
+  @RequiredArgsConstructor
+  public class RequestAwareLoginSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+
+  private final UserJwtGenerator jwtGenerator;
+  private final UserAuthRepository userAuthRepository;
+
+  @Override
+  public void onAuthenticationSuccess(
+      HttpServletRequest request, HttpServletResponse response, Authentication authentication)
+      throws IOException, ServletException {
+
+    if (authentication instanceof UsernamePasswordAuthenticationToken token) {
+      User user = (User) token.getPrincipal();
+
+      if (Objects.nonNull(user)) {
+        Long userId = getUserId(user.getUsername());
+        Collection<? extends GrantedAuthority> authorities = user.getAuthorities();
+        String accessToken = jwtGenerator.createAccessToken(userId, authorities).getTokenValue();
+        String refreshToken = jwtGenerator.createRefreshToken(userId).getTokenValue();
+
+        CookieUtils.addTokenCookies(response, accessToken, refreshToken);
+      } else {
+        log.warn("UserDetails is null");
+        throw new IllegalStateException("UserDetails should be not null");
+      }
+    }
+
+    // SavedRequest(예: OAuth2 redirect)로 이동
+    super.onAuthenticationSuccess(request, response, authentication);
+  }
+
+  private Long getUserId(String loginId) {
+    return userAuthRepository
+        .findUserIdByLoginId(loginId)
+        .orElseThrow(
+            () -> new UsernameNotFoundException("username %s not found".formatted(loginId)))
+        .getValue();
+  }
+}

--- a/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/RequestAwareLoginSuccessHandler.java
+++ b/bank/src/main/java/com/fisa/bank/domains/common/config/security/resource/RequestAwareLoginSuccessHandler.java
@@ -21,12 +21,10 @@ import com.fisa.bank.domains.common.config.security.jwt.UserJwtGenerator;
 import com.fisa.bank.domains.common.presentation.util.CookieUtils;
 import com.fisa.bank.domains.user.persistence.repository.UserAuthRepository;
 
-/**
- * 폼 로그인 성공 시 JWT 쿠키를 심은 뒤, SavedRequest로 리다이렉트한다.
- */
-  @Slf4j
-  @RequiredArgsConstructor
-  public class RequestAwareLoginSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+/** 폼 로그인 성공 시 JWT 쿠키를 심은 뒤, SavedRequest로 리다이렉트한다. */
+@Slf4j
+@RequiredArgsConstructor
+public class RequestAwareLoginSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
 
   private final UserJwtGenerator jwtGenerator;
   private final UserAuthRepository userAuthRepository;

--- a/bank/src/main/resources/templates/login.html
+++ b/bank/src/main/resources/templates/login.html
@@ -124,32 +124,6 @@
       status.textContent = '로그아웃 되었습니다.';
     }
 
-    const form = document.getElementById('login-form');
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      status.textContent = '로그인 중입니다...';
-      const formData = new URLSearchParams();
-      formData.append('username', document.getElementById('username').value.trim());
-      formData.append('password', document.getElementById('password').value);
-
-      try {
-        const res = await fetch('/login', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: formData.toString(),
-          credentials: 'include',
-        });
-
-        if (res.ok) {
-          status.textContent = '로그인에 성공했습니다. 잠시 후 이동합니다...';
-          setTimeout(() => (window.location.href = '/'), 500);
-        } else {
-          status.textContent = '로그인 실패: 아이디/비밀번호를 확인하세요.';
-        }
-      } catch (err) {
-        status.textContent = '로그인 중 오류가 발생했습니다: ' + err.message;
-      }
-    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## 로그인 성공 시 리다이렉트 오류
- 현재 `AuthenticationSuccessHandler` 를 `implements` 하여 직접 구현한 `LoginSuccessHandler` 는 로그인이 성공하면, JWT 와 Cookie에 인증 정보를 담아서 응답합니다.
- 하지만 이 핸들러를 OAuth2.0 로그인 방식에서 그대로 사용하면, `ResourceOwner`가 로그인 성공 시, `/` 페이지로 리다이렉트되는 오류가 존재합니다. 그렇기 때문에, `RequestAwareLoginSuccessHandler`를 별도로 구현하여, 해당 핸들러를 시큐리티 기본 `login` 페이지에서 사용할 수 있도록 합니다.