### PR TITLE
[FIX] deploy.sh 복사 및 권한 부여, 오타 수정

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,8 +82,11 @@ pipeline {
                 ]) {
                     sshagent(['from-jenkins-to-aws-ec2-access-key']) {
                         sh """
+                            scp -o StrictHostKeyChecking=yes deploy.sh $SSH_USER@$DEPLOY_HOST_CORE:~/Core-Banking-Server/
+                        """
+                        sh """
                             ssh -o StrictHostKeyChecking=yes $SSH_USER@$DEPLOY_HOST_CORE \\
-                                'cd ~/Loan-Mate-Backend && ./deploy.sh ${env.BUILD_NUMBER}'
+                                'cd ~/Core-Banking-Server && ./deploy.sh ${env.BUILD_NUMBER}'
                         """
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,6 +91,26 @@ pipeline {
                     }
                 }
             }
+
+            post {
+                success {
+                    withCredentials([string(credentialsId: 'core-discord-webhook', variable: 'DISCORD_WEBHOOK')]) {
+                        discordSend description: "✅ **[${env.BRANCH_NAME}]** 배포 성공했습니다.",
+                            link: env.BUILD_URL,
+                            title: env.JOB_NAME,
+                            webhookURL: DISCORD_WEBHOOK
+                    }
+                }
+                failure {
+                    withCredentials([string(credentialsId: 'core-discord-webhook', variable: 'DISCORD_WEBHOOK')]) {
+                        discordSend description: "❌ **[${env.BRANCH_NAME}]** 배포 실패했습니다.",
+                            link: env.BUILD_URL,
+                            title: env.JOB_NAME,
+                            result: 'FAILURE',
+                            webhookURL: DISCORD_WEBHOOK
+                    }
+                }
+            }
         }
 
         stage('SonarQube Analysis') {
@@ -115,14 +135,6 @@ pipeline {
     post {
         success {
             echo 'Spotless & Build succeeded! Merge allowed.'
-            withCredentials([string(credentialsId: 'core-discord-webhook', variable: 'DISCORD_WEBHOOK')]) {
-                discordSend(
-                    description: "배포 성공했습니다.",
-                    link: env.BUILD_URL,
-                    title: env.JOB_NAME,
-                    webhookURL: DISCORD_WEBHOOK
-                )
-            }
         }
         failure {
             echo 'Spotless or Build failed. Merge not allowed!'


### PR DESCRIPTION
## 관련 이슈
#139 

## 수정 사항
- 최신 deploy.sh을 실행하도록 복사하는 스크립트 추가
- deploy.sh 권한은 서버에 직접 부여
- 대상 서버 이름 오타 수정
